### PR TITLE
fix(ci): pinear pnpm@10.33.4, desbloquear ERR_PNPM_IGNORED_BUILDS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:
@@ -37,8 +35,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# pnpm 10 migró onlyBuiltDependencies de package.json al npmrc
+onlyBuiltDependencies[]=@parcel/watcher
+onlyBuiltDependencies[]=@swc/core
+onlyBuiltDependencies[]=sharp
+onlyBuiltDependencies[]=unrs-resolver

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dimoe-landing",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -16,9 +17,6 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "resend": "^6.12.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["@parcel/watcher", "@swc/core", "sharp", "unrs-resolver"]
   },
   "devDependencies": {
     "@playwright/test": "^1.52",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   reporter: 'line',
   use: { baseURL: `http://localhost:${PORT}`, headless: true },
   webServer: {
-    command: `pnpm dev -- --port ${PORT}`,
+    command: `pnpm dev --port ${PORT}`,
     port: PORT,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -5,7 +5,7 @@ test.describe('Secciones principales', () => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText(/auténtica pizza/i);
     await expect(page.getByText(/35 minutos de Santiago/i)).toBeVisible();
-    const cta = page.getByRole('link', { name: /reservar mesa/i });
+    const cta = page.locator('#inicio').getByRole('link', { name: /reservar mesa/i });
     await expect(cta).toBeVisible();
     await expect(cta).toHaveAttribute('href', /wa\.me\/56973694101/);
   });


### PR DESCRIPTION
## Root cause real

`ci.yml` usaba `pnpm/action-setup@v4` con `version: latest`, que hoy resuelve pnpm 11.x. pnpm 11 eliminó `onlyBuiltDependencies` (y el soporte de ese setting en `.npmrc`) a favor de `allowBuilds` en `pnpm-workspace.yaml`. El primer intento de este PR migró el setting a `.npmrc`, válido solo para pnpm 10 — el CI seguía fallando porque nunca corre pnpm 10.

## Fix
- `packageManager: pnpm@10.33.4` pineado en `package.json` (misma versión que ya usa el equipo en local).
- `pnpm/action-setup@v4` sin `version: latest` — ahora lee la versión pineada.
- Limpiado el campo obsoleto `pnpm.onlyBuiltDependencies` de `package.json`.
- Bonus: `playwright.config.ts` pasaba `pnpm dev -- --port` — pnpm reenvía el `--` literal (a diferencia de npm) y rompe `next dev`. Quitado el separador.
- Bonus: `landing.spec.ts` tenía un locator sin scope que resolvía a 2 elementos ("Reservar mesa" existe en Hero y en LocationStrip, por diseño) — scopeado a `#inicio`.

## Verificación local
- `pnpm install --frozen-lockfile` ✅
- `pnpm tsc --noEmit` ✅
- `pnpm run build` ✅
- `pnpm run test:e2e` → **28/28 passed** ✅

## Impacto
Desbloquea CI de #71, #58 y futuros PRs.

Closes #74, Closes #75