### PR TITLE
feat(menu): subtabs de navegación en BAR y VINOS (feature #105)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -52,14 +52,14 @@ body {
 
 /* Tabs de /carta: fila con scroll horizontal en mobile en vez de wrap */
 @media (max-width: 767px) {
-  .menu-tabs {
+  .menu-tabs, .menu-subtabs {
     flex-wrap: nowrap !important;
     justify-content: flex-start !important;
     overflow-x: auto !important;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
-  .menu-tabs::-webkit-scrollbar { display: none; }
+  .menu-tabs::-webkit-scrollbar, .menu-subtabs::-webkit-scrollbar { display: none; }
 }
 
 /* Textura de piedra/mármol CSS-only para el fondo de /carta — sin imágenes, solo gradientes */

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -52,7 +52,22 @@ const TAB_SEPARATOR_PHOTO: Partial<Record<MenuTab, { src: string; pos: string }>
 // Subtabs de navegación dentro de un tab activo — mapea group.name → bucket.
 // Grupos sin entrada caen en "Otros" (no desaparecen silenciosamente).
 // Poblado por tarea: BAR (#107), VINOS (#108). Vacío = sin subtabs, comportamiento actual.
-const TAB_SUBTABS: Partial<Record<MenuTab, Record<string, string>>> = {};
+const TAB_SUBTABS: Partial<Record<MenuTab, Record<string, string>>> = {
+  BAR: {
+    'Happy Hour': 'Happy Hour',
+    'Gin Frutal': 'Cócteles',
+    'Coctelería de la Casa': 'Cócteles',
+    'Spritz': 'Cócteles',
+    'Sours': 'Cócteles',
+    'Coctelería Clásica': 'Cócteles',
+    'Cervezas Artesanales — La Casona': 'Cerveza',
+    'Vinos y Espumantes': 'Vino y Espumante',
+    'Sin Alcohol': 'Sin Alcohol',
+    'Jugos y Bebidas': 'Sin Alcohol',
+    'Tragos': 'Destilados',
+    'Shots': 'Destilados',
+  },
+};
 
 const TAB_DISPLAY: Record<MenuTab, string> = {
   ENTRADAS: 'ANTIPASTI',
@@ -82,13 +97,16 @@ export default function Menu({ menu }: Props) {
   const tabsRef = useRef<HTMLDivElement>(null);
   const bg = active ? TAB_BG[active] : '#0D0B09';
 
-  // Subtabs del tab activo — sin config para ese tab = sin filtrado (comportamiento actual)
+  // Subtabs del tab activo — sin config para ese tab = sin filtrado (comportamiento actual).
+  // Los buckets se derivan de los grupos realmente presentes (no del mapeo completo),
+  // para no ofrecer un subtab que lleve a una sección vacía si el contenido real (Notion)
+  // todavía no tiene grupos para ese bucket.
   const subtabConfig = active ? TAB_SUBTABS[active] : undefined;
-  const hasUnmappedGroup = subtabConfig
-    ? groups.some(g => !((g.name ?? '') in subtabConfig))
-    : false;
+  const presentBuckets = subtabConfig
+    ? groups.map(g => subtabConfig[g.name ?? ''] ?? 'Otros')
+    : [];
   const subtabLabels = subtabConfig
-    ? ['Todos', ...Array.from(new Set(Object.values(subtabConfig))), ...(hasUnmappedGroup ? ['Otros'] : [])]
+    ? ['Todos', ...Array.from(new Set(presentBuckets))]
     : [];
   const groupsInSubtabs = subtabConfig
     ? groups.filter(g => activeSubtab === 'Todos' || (subtabConfig[g.name ?? ''] ?? 'Otros') === activeSubtab)

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -7,6 +7,8 @@ import { useTranslations, useLocale } from 'next-intl';
 import type { MenuTab, MenuGroup } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
 import MenuSubtabs from './MenuSubtabs';
+import ScrollFadeEdges from './ScrollFadeEdges';
+import { useScrollFade } from './use-scroll-fade';
 
 const TABS: MenuTab[] = ['ENTRADAS', 'PIZZAS', 'FONDOS', 'POSTRES', 'BAR', 'VINOS', 'SEMANAL'];
 
@@ -104,6 +106,7 @@ export default function Menu({ menu }: Props) {
   const resolvedMenu = menu ?? FALLBACK_MENU;
   const groups = active ? resolvedMenu[active] : [];
   const tabsRef = useRef<HTMLDivElement>(null);
+  const tabsFade = useScrollFade(tabsRef);
   const bg = active ? TAB_BG[active] : '#0D0B09';
 
   // Subtabs del tab activo — sin config para ese tab = sin filtrado (comportamiento actual).
@@ -179,13 +182,14 @@ export default function Menu({ menu }: Props) {
       )}
 
       {/* Sticky tabs */}
-      <div ref={tabsRef} className="menu-tabs" style={{
+      <div ref={tabsRef} className="menu-tabs" onScroll={tabsFade.onScroll} style={{
         position: 'sticky', top: 0, zIndex: 10,
         background: bg, transition: 'background-color 0.45s ease',
         paddingTop: '14px', paddingBottom: '14px',
         display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '4px', flexWrap: 'wrap',
         paddingLeft: '16px', paddingRight: '16px',
       }}>
+        <ScrollFadeEdges bg={bg} showLeft={tabsFade.showLeft} showRight={tabsFade.showRight} />
         {/* Home — vuelve al selector de secciones de la carta, no al sitio */}
         <button onClick={handleHome} aria-label="Inicio de la carta" style={{
           display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
@@ -313,7 +317,7 @@ export default function Menu({ menu }: Props) {
           )}
         </div>
 
-        <MenuSubtabs labels={subtabLabels} active={activeSubtab} onChange={setActiveSubtab} />
+        <MenuSubtabs labels={subtabLabels} active={activeSubtab} onChange={setActiveSubtab} bg={bg} />
 
         <AnimatePresence mode="wait">
           <motion.div key={`${active}-${activeSubtab}`}

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -67,6 +67,15 @@ const TAB_SUBTABS: Partial<Record<MenuTab, Record<string, string>>> = {
     'Tragos': 'Destilados',
     'Shots': 'Destilados',
   },
+  VINOS: {
+    'Sauvignon Blanc': 'Blancos',
+    'Chardonnay': 'Blancos',
+    'Carménère': 'Tintos',
+    'Cabernet Sauvignon': 'Tintos',
+    'Merlot': 'Tintos',
+    'Ensamblajes': 'Ensamblajes y Dulce',
+    'Dulce': 'Ensamblajes y Dulce',
+  },
 };
 
 const TAB_DISPLAY: Record<MenuTab, string> = {

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -29,7 +29,7 @@ const TAB_PHOTO: Record<MenuTab, string> = {
   FONDOS:   '/images/menu-fondos-lasagna.jpg',            // Auténtica Lasagna
   POSTRES:  '/images/menu-postres-tiramisu-pistacho.jpg', // Tiramisù Pistacchio
   BAR:      '/images/DSC02288.jpg',   // cóctel berries copa de cristal
-  VINOS:    '/images/DSC02309.jpg',   // ⚠ REVISAR: es una foto de lasagna, no de vinos. Se revisaron 5 candidatas (DSC02223/02385/02439/02458 + esta) y ninguna sirve — falta subir una foto real de vinos/copas a /public/images y actualizar este path.
+  VINOS:    '/images/DSC02288.jpg',   // reutiliza la foto de BAR — sin foto real de vinos/copas disponible aún (mejor que la lasagna anterior)
   SEMANAL:  '/images/DSC02214.jpg',   // pappardelle al camarón, menú especial
 };
 
@@ -39,7 +39,7 @@ const TAB_PHOTO_POS: Record<MenuTab, string> = {
   FONDOS:   'center 45%',
   POSTRES:  'center 60%',
   BAR:      'center 55%',
-  VINOS:    'center 50%',
+  VINOS:    'center 55%',
   SEMANAL:  'center 55%',
 };
 

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslations, useLocale } from 'next-intl';
 import type { MenuTab, MenuGroup } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
+import MenuSubtabs from './MenuSubtabs';
 
 const TABS: MenuTab[] = ['ENTRADAS', 'PIZZAS', 'FONDOS', 'POSTRES', 'BAR', 'VINOS', 'SEMANAL'];
 
@@ -48,6 +49,11 @@ const TAB_SEPARATOR_PHOTO: Partial<Record<MenuTab, { src: string; pos: string }>
   POSTRES:  { src: '/images/menu-postres-tiramisu-pistacho.jpg', pos: 'center 55%' },
 };
 
+// Subtabs de navegación dentro de un tab activo — mapea group.name → bucket.
+// Grupos sin entrada caen en "Otros" (no desaparecen silenciosamente).
+// Poblado por tarea: BAR (#107), VINOS (#108). Vacío = sin subtabs, comportamiento actual.
+const TAB_SUBTABS: Partial<Record<MenuTab, Record<string, string>>> = {};
+
 const TAB_DISPLAY: Record<MenuTab, string> = {
   ENTRADAS: 'ANTIPASTI',
   PIZZAS:   'PIZZAS',
@@ -70,10 +76,23 @@ export default function Menu({ menu }: Props) {
   const t = useTranslations('menu');
   const locale = useLocale();
   const [active, setActive] = useState<MenuTab | null>(null);
+  const [activeSubtab, setActiveSubtab] = useState('Todos');
   const resolvedMenu = menu ?? FALLBACK_MENU;
   const groups = active ? resolvedMenu[active] : [];
   const tabsRef = useRef<HTMLDivElement>(null);
   const bg = active ? TAB_BG[active] : '#0D0B09';
+
+  // Subtabs del tab activo — sin config para ese tab = sin filtrado (comportamiento actual)
+  const subtabConfig = active ? TAB_SUBTABS[active] : undefined;
+  const hasUnmappedGroup = subtabConfig
+    ? groups.some(g => !((g.name ?? '') in subtabConfig))
+    : false;
+  const subtabLabels = subtabConfig
+    ? ['Todos', ...Array.from(new Set(Object.values(subtabConfig))), ...(hasUnmappedGroup ? ['Otros'] : [])]
+    : [];
+  const groupsInSubtabs = subtabConfig
+    ? groups.filter(g => activeSubtab === 'Todos' || (subtabConfig[g.name ?? ''] ?? 'Otros') === activeSubtab)
+    : groups;
 
   // Punto de corte para el separador de foto: después del grupo donde se acumulan
   // ≥6 items, sin insertar justo antes del cierre de la sección.
@@ -81,8 +100,8 @@ export default function Menu({ menu }: Props) {
   let sepIndex = -1;
   if (sepPhoto) {
     let count = 0;
-    for (let i = 0; i < groups.length - 1; i++) {
-      count += groups[i].items.length;
+    for (let i = 0; i < groupsInSubtabs.length - 1; i++) {
+      count += groupsInSubtabs[i].items.length;
       if (count >= 6) { sepIndex = i; break; }
     }
   }
@@ -91,6 +110,10 @@ export default function Menu({ menu }: Props) {
     const hash = window.location.hash.slice(1).toUpperCase() as MenuTab;
     if (TABS.includes(hash)) setActive(hash);
   }, []);
+
+  useEffect(() => {
+    setActiveSubtab('Todos');
+  }, [active]);
 
   useEffect(() => {
     if (!active) return;
@@ -263,12 +286,14 @@ export default function Menu({ menu }: Props) {
           )}
         </div>
 
+        <MenuSubtabs labels={subtabLabels} active={activeSubtab} onChange={setActiveSubtab} />
+
         <AnimatePresence mode="wait">
-          <motion.div key={active}
+          <motion.div key={`${active}-${activeSubtab}`}
             initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.28 }}
           >
-            {groups.map((group, gi) => {
+            {groupsInSubtabs.map((group, gi) => {
               const isHappyHour = group.name === 'Happy Hour';
               const isKids = group.name === 'Para Niños';
               const isSemanaleChef = active === 'SEMANAL' && group.name === 'Menú del Chef';
@@ -278,7 +303,7 @@ export default function Menu({ menu }: Props) {
 
               return (
                 <Fragment key={gi}>
-                <div style={{ marginBottom: gi < groups.length - 1 ? '44px' : 0, paddingTop: gi === 0 ? '32px' : 0 }}>
+                <div style={{ marginBottom: gi < groupsInSubtabs.length - 1 ? '44px' : 0, paddingTop: gi === 0 ? '32px' : 0 }}>
 
                   {/* Menú Semanal — banner carmesí */}
                   {isSemanaleChef && (

--- a/components/sections/MenuSubtabs.tsx
+++ b/components/sections/MenuSubtabs.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+type Props = {
+  labels: string[];
+  active: string;
+  onChange: (label: string) => void;
+};
+
+export default function MenuSubtabs({ labels, active, onChange }: Props) {
+  if (labels.length <= 1) return null;
+
+  return (
+    <div className="menu-subtabs" role="tablist" style={{
+      display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'center',
+      gap: '6px', paddingBottom: '20px', paddingLeft: '16px', paddingRight: '16px',
+    }}>
+      {labels.map(label => {
+        const isActive = active === label;
+        return (
+          <button key={label} role="tab" aria-selected={isActive} onClick={() => onChange(label)}
+            style={{
+              background: isActive ? 'rgba(193,122,59,0.18)' : 'transparent',
+              color: isActive ? '#C17A3B' : 'rgba(242,237,228,0.42)',
+              border: `1px solid ${isActive ? 'rgba(193,122,59,0.5)' : 'rgba(242,237,228,0.12)'}`,
+              padding: '5px 14px', borderRadius: '100px', fontSize: '10px', fontWeight: 600,
+              letterSpacing: '0.1em', cursor: 'pointer', transition: 'all 0.2s',
+              fontFamily: 'var(--font-sans)', flexShrink: 0, textTransform: 'uppercase',
+            }}
+            onMouseEnter={e => { if (!isActive) { e.currentTarget.style.borderColor = 'rgba(193,122,59,0.4)'; e.currentTarget.style.color = 'rgba(242,237,228,0.7)'; } }}
+            onMouseLeave={e => { if (!isActive) { e.currentTarget.style.borderColor = 'rgba(242,237,228,0.12)'; e.currentTarget.style.color = 'rgba(242,237,228,0.42)'; } }}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/sections/MenuSubtabs.tsx
+++ b/components/sections/MenuSubtabs.tsx
@@ -1,19 +1,29 @@
 'use client';
 
+import { useRef } from 'react';
+import { useScrollFade } from './use-scroll-fade';
+import ScrollFadeEdges from './ScrollFadeEdges';
+
 type Props = {
   labels: string[];
   active: string;
   onChange: (label: string) => void;
+  bg: string;
 };
 
-export default function MenuSubtabs({ labels, active, onChange }: Props) {
+export default function MenuSubtabs({ labels, active, onChange, bg }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const fade = useScrollFade(ref);
+
   if (labels.length <= 1) return null;
 
   return (
-    <div className="menu-subtabs" role="tablist" style={{
+    <div ref={ref} className="menu-subtabs" role="tablist" onScroll={fade.onScroll} style={{
+      position: 'relative',
       display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'center',
       gap: '6px', paddingBottom: '20px', paddingLeft: '16px', paddingRight: '16px',
     }}>
+      <ScrollFadeEdges bg={bg} showLeft={fade.showLeft} showRight={fade.showRight} />
       {labels.map(label => {
         const isActive = active === label;
         return (

--- a/components/sections/ScrollFadeEdges.tsx
+++ b/components/sections/ScrollFadeEdges.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+type Props = { bg: string; showLeft: boolean; showRight: boolean };
+
+// Degradado sutil en los bordes de un contenedor con scroll horizontal —
+// avisa que hay más contenido sin scrollbar visible ni flechas.
+export default function ScrollFadeEdges({ bg, showLeft, showRight }: Props) {
+  return (
+    <>
+      <div aria-hidden style={{
+        position: 'absolute', top: 0, bottom: 0, left: 0, width: '28px',
+        background: `linear-gradient(to right, ${bg}, transparent)`,
+        opacity: showLeft ? 1 : 0, transition: 'opacity 0.2s ease', pointerEvents: 'none',
+      }} />
+      <div aria-hidden style={{
+        position: 'absolute', top: 0, bottom: 0, right: 0, width: '28px',
+        background: `linear-gradient(to left, ${bg}, transparent)`,
+        opacity: showRight ? 1 : 0, transition: 'opacity 0.2s ease', pointerEvents: 'none',
+      }} />
+    </>
+  );
+}

--- a/components/sections/use-scroll-fade.ts
+++ b/components/sections/use-scroll-fade.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState, useEffect, useCallback, type RefObject } from 'react';
+
+export function useScrollFade(ref: RefObject<HTMLElement | null>) {
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+
+  const update = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setShowLeft(el.scrollLeft > 2);
+    setShowRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 2);
+  }, [ref]);
+
+  // Sin deps: re-chequea en cada render (el contenido con scroll puede
+  // cambiar de ancho — ej. subtabs — sin disparar un evento de scroll/resize).
+  useEffect(() => {
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  });
+
+  return { showLeft, showRight, onScroll: update };
+}

--- a/lib/menu-fallback.ts
+++ b/lib/menu-fallback.ts
@@ -146,9 +146,9 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
       items: [
         { name: 'Aperol Spritz', desc: 'Naranja', price: 6500 },
         { name: 'Ramazzotti Spritz', desc: 'Flor de Jamaica', price: 6500 },
-        { name: 'Cherry Spritz', desc: 'Guinda', price: 6500 },
+        { name: 'Cherry Spritz', price: 6500 },
         { name: 'Hugo Spritz', desc: 'Flor de Sauco', price: 6500 },
-        { name: 'Limoncello Spritz', desc: 'Licor de limón italiano', price: 6500 },
+        { name: 'Limoncello Spritz', price: 6500 },
       ],
     },
     // 5. Sours

--- a/lib/menu-fallback.ts
+++ b/lib/menu-fallback.ts
@@ -201,15 +201,13 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
         { name: 'Peroni', desc: 'Italiana', price: 4000 },
       ],
     },
-    // 8. Vinos y Espumantes
+    // 8. Vinos y Espumantes — el detalle de vinos vive en la tab VINOS
     {
       name: 'Vinos y Espumantes',
+      subtitle: 'Ver detalle en la carta de Vinos',
       items: [
-        { name: 'Botella Gran Reserva', desc: 'Carmenere · Cabernet Sauvignon · Merlot', price: 20000 },
-        { name: 'Botella Vino Varietal/Reserva', price: '9.000 / 15.000' },
         { name: 'Botella Espumante', price: 12000 },
         { name: 'Copa de Espumante Brut', price: 3500 },
-        { name: 'Copa de Vino Varietal/Reserva', price: '2.500 / 4.500' },
       ],
     },
     // 9. Coctelería Sin Alcohol

--- a/tests/e2e/carta.spec.ts
+++ b/tests/e2e/carta.spec.ts
@@ -32,3 +32,66 @@ test.describe('Carta digital (/carta)', () => {
     await expect(page).toHaveURL(/\/carta\?utm_source=qr$/);
   });
 });
+
+test.describe('Subtabs de BAR y VINOS (/carta)', () => {
+  // VINOS siempre usa FALLBACK_MENU (page.tsx fuerza esto aunque Notion esté configurado),
+  // así que sus 3 subtabs (Blancos, Tintos, Ensamblajes y Dulce) son deterministas.
+  test('VINOS: click en "Tintos" muestra solo los tintos y oculta los blancos', async ({ page }) => {
+    await page.goto('/carta#vinos');
+    await expect(page.getByRole('heading', { name: 'VINOS' })).toBeVisible();
+
+    await expect(page.getByRole('tab', { name: 'Sauvignon Blanc' })).toHaveCount(0); // no es subtab, es grupo
+    await page.getByRole('tab', { name: 'Tintos' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Carménère' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Cabernet Sauvignon' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Merlot' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Chardonnay' })).not.toBeVisible();
+  });
+
+  test('VINOS: subtab "Todos" muestra todos los grupos', async ({ page }) => {
+    await page.goto('/carta#vinos');
+    await page.getByRole('tab', { name: 'Tintos' }).click();
+    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).not.toBeVisible();
+
+    await page.getByRole('tab', { name: 'Todos' }).click();
+    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Carménère' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Dulce' })).toBeVisible();
+  });
+
+  test('cambiar de tab principal resetea el subtab activo a "Todos"', async ({ page }) => {
+    await page.goto('/carta#vinos');
+    await page.getByRole('tab', { name: 'Tintos' }).click();
+    await expect(page.getByRole('tab', { name: 'Tintos' })).toHaveAttribute('aria-selected', 'true');
+
+    await page.getByRole('button', { name: /^BAR$/ }).click();
+    await page.getByRole('button', { name: /^VINOS$/ }).click();
+
+    await expect(page.getByRole('tab', { name: 'Todos' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).toBeVisible();
+  });
+
+  // BAR puede venir de Notion (contenido variable) — se valida el comportamiento de
+  // filtrado, no un bucket ni conteo de grupos específico, para no depender del
+  // contenido real cargado en cada corrida.
+  test('BAR: click en un subtab distinto de "Todos" filtra el contenido mostrado', async ({ page }) => {
+    await page.goto('/carta#bar');
+    await expect(page.getByRole('heading', { name: 'BAR' })).toBeVisible();
+
+    const tabNames = await page.getByRole('tab').allTextContents();
+    expect(tabNames).toContain('Todos');
+    const otherTabs = tabNames.filter(name => name !== 'Todos');
+    expect(otherTabs.length).toBeGreaterThan(0);
+
+    const contentBefore = await page.locator('body').innerText();
+    await page.getByRole('tab', { name: otherTabs[0], exact: true }).click();
+    await expect(page.getByRole('tab', { name: otherTabs[0], exact: true })).toHaveAttribute('aria-selected', 'true');
+
+    await expect(async () => {
+      const contentAfter = await page.locator('body').innerText();
+      expect(contentAfter).not.toEqual(contentBefore);
+    }).toPass({ timeout: 2000 });
+  });
+});


### PR DESCRIPTION
Closes #105

## Tasks incluidas
- Closes #106 — feat: Componente de subtabs reutilizable para /carta
- Closes #107 — feat: Subtabs de BAR agrupados por tipo de bebida
- Closes #108 — feat: Subtabs de VINOS agrupados por tipo de vino
- Closes #109 — refactor: Simplificar descripciones redundantes en items de BAR
- Closes #110 — test: Specs Playwright de navegación de subtabs en BAR y VINOS
- Closes #112 — feat: Affordance de scroll horizontal en tabs y subtabs
- Closes #127 — refactor: Simplificar "Vinos y Espumantes" en BAR, apuntar a tab VINOS

## Resumen
- Subtabs de navegación dentro de BAR (6 buckets: Happy Hour, Cócteles, Cerveza, Vino y Espumante, Sin Alcohol, Destilados) y VINOS (Blancos, Tintos, Ensamblajes y Dulce) — solo se muestran los buckets con contenido presente, nunca uno vacío.
- Simplificación de contenido: descripciones redundantes en Spritz/Limoncello, y el grupo "Vinos y Espumantes" de BAR ahora apunta a la tab VINOS en vez de duplicar precios.
- Affordance de scroll horizontal (degradado en los bordes) para tabs principales y subtabs en mobile.

## Test plan
- [x] `pnpm build` verde
- [x] 40/40 Playwright (32 existentes + 4 nuevos de subtabs + 4 de atención al cliente ya en dev)
- [x] Verificado visualmente a 375px: fade aparece/desaparece según haya contenido oculto
- [ ] Revisar preview de Vercel antes de mergear

🤖 Generated with [Claude Code](https://claude.com/claude-code)