### PR TITLE
feat(menu): publicación controlada de la carta desde Notion (feature #118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ test-results/
 .vercel
 .env*
 tsconfig.tsbuildinfo
+
+# Backups locales de Notion (scripts/backup-menu.mjs) — no commitear al repo
+backups/

--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -27,8 +27,16 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
     ? { ...notionData, VINOS: FALLBACK_MENU.VINOS, SEMANAL: FALLBACK_MENU.SEMANAL }
     : FALLBACK_MENU;
 
+  const publishedData = isPreview ? await getMenu(locale) : null;
+  const hasUnpublishedChanges = isPreview && JSON.stringify(notionData) !== JSON.stringify(publishedData);
+
   return (
     <main style={{ background: '#0D0B09' }}>
+      {hasUnpublishedChanges && (
+        <div style={{ background: '#B45309', color: '#FFF7ED', textAlign: 'center', padding: '10px 16px', fontSize: '14px', fontWeight: 600 }}>
+          ⚠️ {isEn ? 'There are unpublished changes' : 'Hay cambios sin publicar'}
+        </div>
+      )}
       {/* Back link */}
       <div style={{ maxWidth: '860px', margin: '0 auto', padding: '24px clamp(16px, 4vw, 24px) 0' }}>
         <Link href="/" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: 'rgba(242,237,228,0.45)', textDecoration: 'none', transition: 'color 0.2s' }}>

--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
+import { draftMode } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import Menu from '@/components/sections/Menu';
 import CartaFooter from '@/components/sections/CartaFooter';
-import { getMenu } from '@/lib/menu';
+import { getMenu, getMenuPreview } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
@@ -20,7 +21,8 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 export default async function CartaPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const isEn = locale === 'en';
-  const notionData = await getMenu(locale);
+  const { isEnabled: isPreview } = await draftMode();
+  const notionData = isPreview ? await getMenuPreview(locale) : await getMenu(locale);
   const menuData = notionData
     ? { ...notionData, VINOS: FALLBACK_MENU.VINOS, SEMANAL: FALLBACK_MENU.SEMANAL }
     : FALLBACK_MENU;

--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -6,8 +6,6 @@ import CartaFooter from '@/components/sections/CartaFooter';
 import { getMenu } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
 
-export const revalidate = 300;
-
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
   const isEn = locale === 'en';

--- a/app/api/preview/route.ts
+++ b/app/api/preview/route.ts
@@ -1,0 +1,24 @@
+import { timingSafeEqual } from 'crypto'
+import { draftMode } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const secret = req.nextUrl.searchParams.get('secret') ?? ''
+  const expected = process.env.PUBLISH_SECRET ?? ''
+
+  if (!expected || !secretsMatch(secret, expected)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const draft = await draftMode()
+  draft.enable()
+
+  return NextResponse.redirect(new URL('/carta', req.url))
+}

--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -1,0 +1,104 @@
+import { timingSafeEqual } from 'crypto'
+import { revalidateTag } from 'next/cache'
+import { NextRequest, NextResponse } from 'next/server'
+import { del, get, list, put } from '@vercel/blob'
+
+const NOTION_API = 'https://api.notion.com/v1'
+const NOTION_VERSION = '2022-06-28'
+const MAX_SNAPSHOTS = 10
+
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+async function fetchNotionMenuRaw(): Promise<unknown[]> {
+  const token = process.env.NOTION_ACCESS_TOKEN
+  const dbId = process.env.NOTION_DB_MENU
+  const results: unknown[] = []
+  let cursor: string | undefined
+
+  do {
+    const res = await fetch(`${NOTION_API}/databases/${dbId}/query`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': NOTION_VERSION,
+      },
+      body: JSON.stringify({
+        filter: { property: 'Activo', checkbox: { equals: true } },
+        sorts: [{ property: 'Orden', direction: 'ascending' }],
+        page_size: 100,
+        ...(cursor ? { start_cursor: cursor } : {}),
+      }),
+      cache: 'no-store',
+    })
+    if (!res.ok) throw new Error(`Notion API respondió ${res.status}`)
+
+    const data = await res.json() as { results: unknown[]; has_more: boolean; next_cursor: string | null }
+    results.push(...data.results)
+    cursor = data.has_more ? (data.next_cursor ?? undefined) : undefined
+  } while (cursor)
+
+  return results
+}
+
+async function readBlobJson(pathname: string): Promise<unknown[] | null> {
+  const result = await get(pathname, { access: 'private', useCache: false })
+  if (!result) return null
+  const text = await new Response(result.stream).text()
+  return JSON.parse(text) as unknown[]
+}
+
+async function writeBlobJson(pathname: string, data: unknown[]): Promise<void> {
+  await put(pathname, JSON.stringify(data), {
+    access: 'private',
+    addRandomSuffix: false,
+    allowOverwrite: true,
+    contentType: 'application/json',
+  })
+}
+
+async function pruneOldSnapshots(): Promise<void> {
+  const { blobs } = await list({ prefix: 'menu-snapshots/' })
+  if (blobs.length <= MAX_SNAPSHOTS) return
+
+  const sorted = [...blobs].sort((a, b) => b.uploadedAt.getTime() - a.uploadedAt.getTime())
+  const toDelete = sorted.slice(MAX_SNAPSHOTS).map(b => b.url)
+  if (toDelete.length > 0) await del(toDelete)
+}
+
+function htmlResponse(title: string, body: string): NextResponse {
+  return new NextResponse(
+    `<!doctype html><html><body style="font-family:system-ui,sans-serif;text-align:center;padding:64px"><h1>${title}</h1><p>${body}</p></body></html>`,
+    { headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+  )
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const secret = req.nextUrl.searchParams.get('secret') ?? ''
+  const expected = process.env.PUBLISH_SECRET ?? ''
+
+  if (!expected || !secretsMatch(secret, expected)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const currentLive = await readBlobJson('menu-live.json')
+
+  if (currentLive !== null) {
+    await writeBlobJson('menu-previous.json', currentLive)
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    await writeBlobJson(`menu-snapshots/${timestamp}.json`, currentLive)
+    await pruneOldSnapshots()
+  }
+
+  const fresh = await fetchNotionMenuRaw()
+  await writeBlobJson('menu-live.json', fresh)
+
+  revalidateTag('menu', 'max')
+
+  return htmlResponse('✅ Carta publicada', `${fresh.length} items actualizados.`)
+}

--- a/app/api/undo/route.ts
+++ b/app/api/undo/route.ts
@@ -1,0 +1,50 @@
+import { timingSafeEqual } from 'crypto'
+import { revalidateTag } from 'next/cache'
+import { NextRequest, NextResponse } from 'next/server'
+import { get, put } from '@vercel/blob'
+
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+async function readBlobJson(pathname: string): Promise<unknown[] | null> {
+  const result = await get(pathname, { access: 'private', useCache: false })
+  if (!result) return null
+  const text = await new Response(result.stream).text()
+  return JSON.parse(text) as unknown[]
+}
+
+function htmlResponse(title: string, body: string): NextResponse {
+  return new NextResponse(
+    `<!doctype html><html><body style="font-family:system-ui,sans-serif;text-align:center;padding:64px"><h1>${title}</h1><p>${body}</p></body></html>`,
+    { headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+  )
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const secret = req.nextUrl.searchParams.get('secret') ?? ''
+  const expected = process.env.PUBLISH_SECRET ?? ''
+
+  if (!expected || !secretsMatch(secret, expected)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const previous = await readBlobJson('menu-previous.json')
+  if (previous === null) {
+    return htmlResponse('⚠️ No hay versión anterior guardada', 'Todavía no se publicó ningún cambio para poder deshacerlo.')
+  }
+
+  await put('menu-live.json', JSON.stringify(previous), {
+    access: 'private',
+    addRandomSuffix: false,
+    allowOverwrite: true,
+    contentType: 'application/json',
+  })
+
+  revalidateTag('menu', 'max')
+
+  return htmlResponse('↩️ Cambios revertidos', 'La carta volvió a la versión anterior.')
+}

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -1,5 +1,5 @@
-const NOTION_API = 'https://api.notion.com/v1'
-const NOTION_VERSION = '2022-06-28'
+import { unstable_cache } from 'next/cache'
+import { get } from '@vercel/blob'
 
 export type MenuTab = 'ENTRADAS' | 'PIZZAS' | 'FONDOS' | 'POSTRES' | 'BAR' | 'VINOS' | 'SEMANAL'
 
@@ -103,36 +103,26 @@ function parseMenuPages(
   return result
 }
 
+const getPublishedMenuPages = unstable_cache(
+  async (): Promise<NotionMenuPage[] | null> => {
+    try {
+      const result = await get('menu-live.json', { access: 'private', useCache: false })
+      if (!result) return null
+      const text = await new Response(result.stream).text()
+      return JSON.parse(text) as NotionMenuPage[]
+    } catch {
+      return null
+    }
+  },
+  ['menu-live-snapshot'],
+  { tags: ['menu'] },
+)
+
 export async function getMenu(
   locale: string,
 ): Promise<Record<MenuTab, MenuGroup[]> | null> {
-  const token = process.env.NOTION_ACCESS_TOKEN
-  const dbId = process.env.NOTION_DB_MENU
-  if (!token || !dbId || token.length < 10) return null
-
   const isEn = locale === 'en'
-
-  try {
-    const res = await fetch(`${NOTION_API}/databases/${dbId}/query`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'Notion-Version': NOTION_VERSION,
-      },
-      body: JSON.stringify({
-        filter: { property: 'Activo', checkbox: { equals: true } },
-        sorts: [{ property: 'Orden', direction: 'ascending' }],
-        page_size: 200,
-      }),
-      next: { revalidate: 300, tags: ['menu'] },
-    })
-
-    if (!res.ok) return null
-
-    const data = await res.json() as { results: NotionMenuPage[]; has_more: boolean }
-    return parseMenuPages(data.results, isEn)
-  } catch {
-    return null
-  }
+  const pages = await getPublishedMenuPages()
+  if (!pages) return null
+  return parseMenuPages(pages, isEn)
 }

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -1,6 +1,9 @@
 import { unstable_cache } from 'next/cache'
 import { get } from '@vercel/blob'
 
+const NOTION_API = 'https://api.notion.com/v1'
+const NOTION_VERSION = '2022-06-28'
+
 export type MenuTab = 'ENTRADAS' | 'PIZZAS' | 'FONDOS' | 'POSTRES' | 'BAR' | 'VINOS' | 'SEMANAL'
 
 export type MenuItem = {
@@ -125,4 +128,43 @@ export async function getMenu(
   const pages = await getPublishedMenuPages()
   if (!pages) return null
   return parseMenuPages(pages, isEn)
+}
+
+/**
+ * Igual que getMenu, pero pega directo a Notion sin pasar por el Blob publicado
+ * ni el cache de Next — para el modo preview (Draft Mode), donde se quiere ver
+ * el estado actual de Notion aunque todavía no se haya publicado.
+ */
+export async function getMenuPreview(
+  locale: string,
+): Promise<Record<MenuTab, MenuGroup[]> | null> {
+  const token = process.env.NOTION_ACCESS_TOKEN
+  const dbId = process.env.NOTION_DB_MENU
+  if (!token || !dbId || token.length < 10) return null
+
+  const isEn = locale === 'en'
+
+  try {
+    const res = await fetch(`${NOTION_API}/databases/${dbId}/query`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': NOTION_VERSION,
+      },
+      body: JSON.stringify({
+        filter: { property: 'Activo', checkbox: { equals: true } },
+        sorts: [{ property: 'Orden', direction: 'ascending' }],
+        page_size: 200,
+      }),
+      cache: 'no-store',
+    })
+
+    if (!res.ok) return null
+
+    const data = await res.json() as { results: NotionMenuPage[]; has_more: boolean }
+    return parseMenuPages(data.results, isEn)
+  } catch {
+    return null
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:e2e": "playwright test --reporter=line"
   },
   "dependencies": {
+    "@vercel/blob": "^2.6.1",
     "framer-motion": "^12",
     "next": "16.2.10",
     "next-intl": "^4.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@vercel/blob':
+        specifier: ^2.6.1
+        version: 2.6.1
       framer-motion:
         specifier: ^12
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -954,6 +957,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/blob@2.6.1':
+    resolution: {integrity: sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@1.0.0':
+    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+
+  '@vercel/oidc@3.8.0':
+    resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
+    engines: {node: '>= 20'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1016,6 +1034,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1332,6 +1353,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1428,6 +1453,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -1495,6 +1524,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   icu-minify@4.13.1:
     resolution: {integrity: sha512-nFYW2im0WJ3RUVZwabd71J8QTZRtkK1xxZBY7klg7a6KS/os17LZSj9q1VhbRSnk3S8Mv2I7F1izr/aEJ6cUsw==}
 
@@ -1536,6 +1569,10 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -1584,6 +1621,9 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -1603,6 +1643,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -1641,6 +1685,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1785,6 +1832,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1792,6 +1842,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1874,6 +1928,10 @@ packages:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1906,9 +1964,17 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -2027,6 +2093,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2098,6 +2168,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2139,6 +2212,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -2170,6 +2247,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -2230,6 +2311,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -2272,6 +2357,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2284,6 +2377,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3041,6 +3137,30 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vercel/blob@2.6.1':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.27.0
+
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.0':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/oidc@3.8.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3132,6 +3252,10 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -3597,6 +3721,18 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3695,6 +3831,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
+  get-stream@6.0.1: {}
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -3754,6 +3892,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  human-signals@2.1.0: {}
+
   icu-minify@4.13.1:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.12
@@ -3803,6 +3943,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.8.5
@@ -3850,6 +3992,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-node-process@1.2.0: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -3869,6 +4013,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -3910,6 +4056,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4022,12 +4170,16 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mimic-fn@2.1.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4110,6 +4262,10 @@ snapshots:
 
   node-releases@2.0.50: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -4152,6 +4308,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -4160,6 +4320,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  os-paths@4.4.0: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -4269,6 +4431,8 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -4389,6 +4553,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@3.0.7: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
@@ -4456,6 +4622,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@2.0.0: {}
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
@@ -4474,6 +4642,8 @@ snapshots:
   tailwindcss@4.3.2: {}
 
   tapable@2.3.3: {}
+
+  throttleit@2.1.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -4555,6 +4725,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@8.3.0: {}
+
+  undici@6.27.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -4648,6 +4820,15 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
@@ -4655,5 +4836,7 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@4.1.11: {}
 
   zod@4.4.3: {}

--- a/scripts/backup-menu.mjs
+++ b/scripts/backup-menu.mjs
@@ -1,0 +1,85 @@
+/**
+ * One-shot script: exporta el estado ACTUAL completo de la DB Menú de Notion
+ * a un JSON local, con timestamp. Red de seguridad previa al flujo de
+ * publicación controlada (work-item #118) — no escribe nada en Notion.
+ *
+ * Ejecutar con: node scripts/backup-menu.mjs
+ * Requiere NOTION_ACCESS_TOKEN y NOTION_DB_MENU en .env.local
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { resolve } from 'path'
+
+try {
+  const env = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8')
+  for (const line of env.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq < 0) continue
+    const k = line.slice(0, eq).trim()
+    const v = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '')
+    if (k && v && !process.env[k]) process.env[k] = v
+  }
+} catch {
+  // Si no existe .env.local, las vars deben venir del entorno
+}
+
+const TOKEN = process.env.NOTION_ACCESS_TOKEN
+const DB_ID = process.env.NOTION_DB_MENU
+
+if (!TOKEN || TOKEN.length < 10) {
+  console.error('❌  Falta NOTION_ACCESS_TOKEN en .env.local')
+  process.exit(1)
+}
+if (!DB_ID) {
+  console.error('❌  Falta NOTION_DB_MENU en .env.local')
+  process.exit(1)
+}
+
+const HEADERS = {
+  Authorization: `Bearer ${TOKEN}`,
+  'Content-Type': 'application/json',
+  'Notion-Version': '2022-06-28',
+}
+
+async function fetchAllPages() {
+  const results = []
+  let cursor = undefined
+
+  do {
+    const res = await fetch(`https://api.notion.com/v1/databases/${DB_ID}/query`, {
+      method: 'POST',
+      headers: HEADERS,
+      body: JSON.stringify({
+        page_size: 100,
+        ...(cursor ? { start_cursor: cursor } : {}),
+      }),
+    })
+    const data = await res.json()
+    if (!res.ok) throw new Error(`Notion API: ${JSON.stringify(data)}`)
+
+    results.push(...data.results)
+    cursor = data.has_more ? data.next_cursor : undefined
+  } while (cursor)
+
+  return results
+}
+
+async function main() {
+  console.log('🔎  Exportando DB Menú completa de Notion...\n')
+
+  const pages = await fetchAllPages()
+
+  const timestamp = new Date().toISOString().slice(0, 19).replace(/:/g, '-')
+  mkdirSync(resolve(process.cwd(), 'backups'), { recursive: true })
+  const outPath = resolve(process.cwd(), 'backups', `menu-${timestamp}.json`)
+
+  writeFileSync(outPath, JSON.stringify(pages, null, 2))
+
+  console.log(`✓  ${pages.length} páginas exportadas`)
+  console.log(`✓  Guardado en: ${outPath}`)
+}
+
+main().catch(err => {
+  console.error('❌ ', err.message)
+  process.exit(1)
+})

--- a/scripts/setup-notion-callout.mjs
+++ b/scripts/setup-notion-callout.mjs
@@ -1,0 +1,106 @@
+/**
+ * One-shot script: agrega un callout con los 3 links de publicación controlada
+ * (preview / publicar / deshacer) a la página que contiene la DB Menú en Notion.
+ * Ejecutar UNA sola vez con: node scripts/setup-notion-callout.mjs
+ *
+ * Requiere NOTION_ACCESS_TOKEN, NOTION_DB_MENU y PUBLISH_SECRET en .env.local
+ */
+
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+try {
+  const env = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8')
+  for (const line of env.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq < 0) continue
+    const k = line.slice(0, eq).trim()
+    const v = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '')
+    if (k && v && !process.env[k]) process.env[k] = v
+  }
+} catch {
+  // Si no existe .env.local, las vars deben venir del entorno
+}
+
+const TOKEN = process.env.NOTION_ACCESS_TOKEN
+const DB_ID = process.env.NOTION_DB_MENU
+const SECRET = process.env.PUBLISH_SECRET
+const SITE_URL = process.env.SITE_URL ?? 'https://dev.dimoe.cl'
+
+if (!TOKEN) {
+  console.error('❌  Falta NOTION_ACCESS_TOKEN en .env.local')
+  process.exit(1)
+}
+if (!DB_ID) {
+  console.error('❌  Falta NOTION_DB_MENU en .env.local')
+  process.exit(1)
+}
+if (!SECRET) {
+  console.error('❌  Falta PUBLISH_SECRET en .env.local')
+  process.exit(1)
+}
+
+const HEADERS = {
+  Authorization: `Bearer ${TOKEN}`,
+  'Content-Type': 'application/json',
+  'Notion-Version': '2022-06-28',
+}
+
+async function notion(method, path, body) {
+  const res = await fetch(`https://api.notion.com/v1${path}`, {
+    method,
+    headers: HEADERS,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const data = await res.json()
+  if (!res.ok) throw new Error(`Notion API ${path}: ${JSON.stringify(data)}`)
+  return data
+}
+
+function linkCallout(emoji, label, url) {
+  return {
+    object: 'block',
+    type: 'callout',
+    callout: {
+      icon: { type: 'emoji', emoji },
+      color: 'gray_background',
+      rich_text: [
+        { type: 'text', text: { content: label, link: { url } } },
+      ],
+    },
+  }
+}
+
+function normalizeId(id) {
+  return id.replace(/-/g, '')
+}
+
+async function main() {
+  console.log('🔎  Buscando página padre de la DB Menú...')
+  const db = await notion('GET', `/databases/${DB_ID}`)
+  const parentPageId = db.parent?.page_id
+  if (!parentPageId) throw new Error('La DB Menú no tiene una página padre (parent.page_id ausente)')
+  console.log(`✓  Página padre: ${parentPageId}`)
+
+  const children = await notion('GET', `/blocks/${parentPageId}/children?page_size=50`)
+  const menuDbBlock = children.results.find(b => normalizeId(b.id) === normalizeId(DB_ID))
+  if (!menuDbBlock) throw new Error('No se encontró el bloque de la DB Menú entre los children de la página padre')
+
+  const blocks = [
+    linkCallout('🔍', 'Ver preview', `${SITE_URL}/api/preview?secret=${SECRET}`),
+    linkCallout('📢', 'Publicar carta', `${SITE_URL}/api/publish?secret=${SECRET}`),
+    linkCallout('↩️', 'Deshacer último cambio', `${SITE_URL}/api/undo?secret=${SECRET}`),
+  ]
+
+  console.log('🖊️  Agregando callout con 3 links...')
+  // Notion API no soporta insertar en la posición 0 — se inserta inmediatamente
+  // después del bloque de la propia DB Menú (queda adyacente, no al final de la página).
+  await notion('PATCH', `/blocks/${parentPageId}/children`, { children: blocks, after: menuDbBlock.id })
+
+  console.log('✓  Callout agregado junto a la DB Menú')
+}
+
+main().catch(err => {
+  console.error('❌ ', err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #118

## Tasks incluidas
- Closes #119 — chore: Backup manual de la DB Menú actual a JSON local
- Closes #120 — chore: Crear Vercel Blob store + env vars
- Closes #121 — feat: ruta /api/publish
- Closes #122 — refactor: migrar getMenu() al Blob, quitar revalidate por tiempo
- Closes #123 — feat: ruta /api/undo
- Closes #124 — feat: ruta /api/preview (Draft Mode) + getMenuPreview()
- Closes #125 — chore: script que agrega callout con links a Notion
- Closes #126 — feat: banner "cambios sin publicar" en modo preview

## Resumen
- El sitio público (`/carta`) deja de leer Notion en tiempo real — lee un snapshot propio (`menu-live.json`) en Vercel Blob, invalidado solo on-demand (sin ISR por tiempo).
- El administrador del restaurante opera todo el flujo desde Notion, sin tocar código: un link para previsualizar cambios en vivo (Draft Mode), uno para publicarlos (con snapshot automático del estado anterior) y uno para deshacer el último publish.
- Banner de aviso en preview cuando hay cambios sin publicar.

## Test plan
- [x] `pnpm build` verde
- [x] Ciclo publicar → deshacer → publicar verificado contra el Blob real (`vercel blob list`)
- [x] `getMenu()` probado sin `NOTION_ACCESS_TOKEN` presente → confirma que ya no depende de Notion en vivo
- [x] Preview vs. publicado probado con ediciones reales y reversibles en la Notion de DiMOE
- [x] Banner probado en sus 3 estados (sin cambios / con cambios pendientes / tras publicar)
- [x] Callout de Notion corrido contra la página real, verificado leyendo los bloques de vuelta
- [ ] Validación visual del dev en `dev.dimoe.cl` tras el merge (los 3 links de Notion solo funcionan una vez desplegado)