### PR TITLE
fix(menu): pulido de UX en /carta post-subtabs — scroll y tipografía (fix #136)

### DIFF
--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -107,6 +107,7 @@ export default function Menu({ menu }: Props) {
   const groups = active ? resolvedMenu[active] : [];
   const tabsRef = useRef<HTMLDivElement>(null);
   const tabsFade = useScrollFade(tabsRef);
+  const sectionRef = useRef<HTMLElement>(null);
   const bg = active ? TAB_BG[active] : '#0D0B09';
 
   // Subtabs del tab activo — sin config para ese tab = sin filtrado (comportamiento actual).
@@ -154,6 +155,7 @@ export default function Menu({ menu }: Props) {
   const handleTab = (tab: MenuTab) => {
     setActive(tab);
     window.history.replaceState(null, '', `#${tab.toLowerCase()}`);
+    sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
   const handleHome = () => {
@@ -164,6 +166,7 @@ export default function Menu({ menu }: Props) {
   return (
     <section
       id="menu"
+      ref={sectionRef}
       className="menu-texture"
       style={{
         backgroundColor: bg,

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -331,9 +331,8 @@ export default function Menu({ menu }: Props) {
               const isHappyHour = group.name === 'Happy Hour';
               const isKids = group.name === 'Para Niños';
               const isSemanaleChef = active === 'SEMANAL' && group.name === 'Menú del Chef';
-              const isBarTab = active === 'BAR';
               const noDesc = group.items.every(i => !i.desc);
-              const isCompact = isBarTab || (noDesc && group.items.length > 2);
+              const isCompact = noDesc && group.items.length > 2;
 
               return (
                 <Fragment key={gi}>


### PR DESCRIPTION
Closes #136

## Tasks incluidas
- Closes #137 — fix: Resetear scroll al inicio al cambiar de tab principal en /carta
- Closes #138 — fix: Homologar tipografía de BAR con el resto de las secciones de /carta

## Resumen
- Cambiar de tab principal en /carta ahora siempre lleva al inicio de la nueva sección (antes heredaba el scroll de la sección anterior).
- BAR ya no fuerza modo compacto para todos sus grupos — sigue el mismo criterio que el resto de las secciones (compacto solo sin descripción y más de 2 items), así que los grupos con descripción se ven con el mismo tamaño de letra que FONDOS/DOLCE.

## Test plan
- [x] `pnpm build` verde
- [x] 41/41 Playwright
- [x] Verificado: scroll baja a ~1225px en FONDOS, vuelve a ~48px al cambiar a DOLCE
- [x] Verificado: item de BAR con descripción ahora renderiza a 15px (antes 13px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)