### PR TITLE
fix(menu): timeout de función serverless en /api/publish (fix #143)

### DIFF
--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -7,6 +7,8 @@ import CartaFooter from '@/components/sections/CartaFooter';
 import { getMenu, getMenuPreview } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
 
+export const maxDuration = 30;
+
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params;
   const isEn = locale === 'en';

--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -3,6 +3,8 @@ import { revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
 import { del, get, list, put } from '@vercel/blob'
 
+export const maxDuration = 60
+
 const NOTION_API = 'https://api.notion.com/v1'
 const NOTION_VERSION = '2022-06-28'
 const MAX_SNAPSHOTS = 10

--- a/app/api/undo/route.ts
+++ b/app/api/undo/route.ts
@@ -3,6 +3,8 @@ import { revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
 import { get, put } from '@vercel/blob'
 
+export const maxDuration = 30
+
 function secretsMatch(provided: string, expected: string): boolean {
   const a = Buffer.from(provided)
   const b = Buffer.from(expected)


### PR DESCRIPTION
Closes #143

## Tasks incluidas
- Closes #144 — fix: agregar maxDuration y redeploy

## Resumen
Encontrado en pruebas E2E post-deploy reales del work-item #118: `/api/publish` funcionaba perfecto en local pero daba 500 (body vacío) en producción — timeout de la función serverless de Vercel (Hobby plan, ~10s default) por la cantidad de operaciones secuenciales (Blob + Notion paginado). `getMenuPreview()` sufría el mismo problema pero lo tragaba silenciosamente, cayendo a `FALLBACK_MENU` sin avisar.

Fix: `export const maxDuration` en `/api/publish` (60s), `/api/undo` (30s, margen) y la página `/carta` (30s, cubre `getMenuPreview`).

## Test plan
- [x] `pnpm build` verde
- [ ] Redeploy manual + batería E2E completa contra `dev.dimoe.cl` (publish, undo, preview con edición real en Notion, banner)