### PR TITLE
fix(landing): aclarar CTA de delivery en MenuTeaser (fix #145)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -49,7 +49,7 @@
     "c4_desc": "Starters, wines, desserts and more. Options for everyone: vegetarian, vegan and meat dishes.",
     "order_q": "Can't make it today?",
     "order_title": "Order online and pick up at the restaurant",
-    "order_cta": "View the menu →"
+    "order_cta": "Order for delivery →"
   },
   "reviews": {
     "label": "Reviews",

--- a/messages/es.json
+++ b/messages/es.json
@@ -49,7 +49,7 @@
     "c4_desc": "Entradas, vinos, postres y más. Con opciones para todos los gustos: vegetariano, vegano y carnes.",
     "order_q": "¿No puedes venir hoy?",
     "order_title": "Pide online y retira en nuestro local",
-    "order_cta": "Ver la carta →"
+    "order_cta": "Ver la carta delivery →"
   },
   "reviews": {
     "label": "Reseñas",


### PR DESCRIPTION
Closes #145

## Tasks incluidas
- Closes #146 — fix: Cambiar texto del CTA de delivery en MenuTeaser

## Resumen
- El CTA de la franja de pedidos online decía "Ver la carta →", idéntico al CTA principal de la sección y confuso ya que en realidad lleva al link de delivery. Ahora dice "Ver la carta delivery →" (ES) / "Order for delivery →" (EN).

## Test plan
- [x] `pnpm build` verde
- [x] 41/41 Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)