### PR TITLE
fix(menu): ruta para salir de Draft Mode en /carta (fix #152)

### DIFF
--- a/app/api/preview/exit/route.ts
+++ b/app/api/preview/exit/route.ts
@@ -1,0 +1,24 @@
+import { timingSafeEqual } from 'crypto'
+import { draftMode } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const secret = req.nextUrl.searchParams.get('secret') ?? ''
+  const expected = process.env.PUBLISH_SECRET ?? ''
+
+  if (!expected || !secretsMatch(secret, expected)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const draft = await draftMode()
+  draft.disable()
+
+  return NextResponse.redirect(new URL('/carta', req.url))
+}

--- a/scripts/add-notion-preview-exit-link.mjs
+++ b/scripts/add-notion-preview-exit-link.mjs
@@ -1,0 +1,97 @@
+/**
+ * One-shot script: agrega el callout "Salir de preview" al lado de los otros
+ * 3 links de publicación controlada (ver scripts/setup-notion-callout.mjs).
+ * Ejecutar UNA sola vez con: node scripts/add-notion-preview-exit-link.mjs
+ *
+ * Requiere NOTION_ACCESS_TOKEN, NOTION_DB_MENU y PUBLISH_SECRET en .env.local
+ */
+
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+try {
+  const env = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8')
+  for (const line of env.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq < 0) continue
+    const k = line.slice(0, eq).trim()
+    const v = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '')
+    if (k && v && !process.env[k]) process.env[k] = v
+  }
+} catch {
+  // Si no existe .env.local, las vars deben venir del entorno
+}
+
+const TOKEN = process.env.NOTION_ACCESS_TOKEN
+const DB_ID = process.env.NOTION_DB_MENU
+const SECRET = process.env.PUBLISH_SECRET
+const SITE_URL = process.env.SITE_URL ?? 'https://dev.dimoe.cl'
+
+if (!TOKEN) {
+  console.error('❌  Falta NOTION_ACCESS_TOKEN en .env.local')
+  process.exit(1)
+}
+if (!DB_ID) {
+  console.error('❌  Falta NOTION_DB_MENU en .env.local')
+  process.exit(1)
+}
+if (!SECRET) {
+  console.error('❌  Falta PUBLISH_SECRET en .env.local')
+  process.exit(1)
+}
+
+const HEADERS = {
+  Authorization: `Bearer ${TOKEN}`,
+  'Content-Type': 'application/json',
+  'Notion-Version': '2022-06-28',
+}
+
+async function notion(method, path, body) {
+  const res = await fetch(`https://api.notion.com/v1${path}`, {
+    method,
+    headers: HEADERS,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const data = await res.json()
+  if (!res.ok) throw new Error(`Notion API ${path}: ${JSON.stringify(data)}`)
+  return data
+}
+
+function linkCallout(emoji, label, url) {
+  return {
+    object: 'block',
+    type: 'callout',
+    callout: {
+      icon: { type: 'emoji', emoji },
+      color: 'gray_background',
+      rich_text: [
+        { type: 'text', text: { content: label, link: { url } } },
+      ],
+    },
+  }
+}
+
+async function main() {
+  console.log('🔎  Buscando página padre de la DB Menú...')
+  const db = await notion('GET', `/databases/${DB_ID}`)
+  const parentPageId = db.parent?.page_id
+  if (!parentPageId) throw new Error('La DB Menú no tiene una página padre (parent.page_id ausente)')
+
+  const children = await notion('GET', `/blocks/${parentPageId}/children?page_size=50`)
+  const calloutBlocks = children.results.filter(b => b.type === 'callout')
+  const lastCallout = calloutBlocks[calloutBlocks.length - 1]
+  if (!lastCallout) throw new Error('No se encontraron los callouts existentes (correr primero scripts/setup-notion-callout.mjs)')
+
+  console.log('🖊️  Agregando callout "Salir de preview"...')
+  await notion('PATCH', `/blocks/${parentPageId}/children`, {
+    children: [linkCallout('🚪', 'Salir de preview', `${SITE_URL}/api/preview/exit?secret=${SECRET}`)],
+    after: lastCallout.id,
+  })
+
+  console.log('✓  Callout agregado')
+}
+
+main().catch(err => {
+  console.error('❌ ', err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #152

## Tasks incluidas
- Closes #153 — feat: ruta /api/preview/exit
- Closes #154 — chore: link de "Salir de preview" en Notion

## Resumen
Encontrado durante las pruebas E2E post-deploy del work-item #118: `/api/preview` activaba Draft Mode pero no existía forma de desactivarlo. Cualquiera que abriera el link "Ver preview" de Notion quedaba viendo la vista de preview (con su banner) en ese navegador hasta cerrar el navegador por completo — patrón estándar de Next.js Draft Mode que siempre requiere una ruta enable + disable.

## Test plan
- [x] `pnpm build` verde
- [x] Callout de Notion verificado con 4 links (preview, publicar, deshacer, salir)
- [ ] Redeploy manual + probar el link real de "Salir de preview" contra `dev.dimoe.cl`