### PR TITLE
fix(menu): indicador visible de modo preview con link de salir (fix #156)

### DIFF
--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -31,12 +31,20 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
 
   const publishedData = isPreview ? await getMenu(locale) : null;
   const hasUnpublishedChanges = isPreview && JSON.stringify(notionData) !== JSON.stringify(publishedData);
+  const previewExitUrl = `/api/preview/exit?secret=${process.env.PUBLISH_SECRET ?? ''}`;
 
   return (
     <main style={{ background: '#0D0B09' }}>
-      {hasUnpublishedChanges && (
-        <div style={{ background: '#B45309', color: '#FFF7ED', textAlign: 'center', padding: '10px 16px', fontSize: '14px', fontWeight: 600 }}>
-          ⚠️ {isEn ? 'There are unpublished changes' : 'Hay cambios sin publicar'}
+      {isPreview && (
+        <div style={{ background: hasUnpublishedChanges ? '#B45309' : '#3F3F46', color: '#FFF7ED', textAlign: 'center', padding: '10px 16px', fontSize: '14px', fontWeight: 600, display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'center', gap: '8px' }}>
+          <span>
+            {hasUnpublishedChanges
+              ? (isEn ? '⚠️ There are unpublished changes' : '⚠️ Hay cambios sin publicar')
+              : (isEn ? '👁️ Preview mode active' : '👁️ Modo preview activo')}
+          </span>
+          <a href={previewExitUrl} style={{ color: '#FFF7ED', textDecoration: 'underline', fontWeight: 700 }}>
+            {isEn ? '🚪 Exit preview' : '🚪 Salir de preview'}
+          </a>
         </div>
       )}
       {/* Back link */}


### PR DESCRIPTION
Closes #156

## Tasks incluidas
- Closes #157 — feat: indicador de modo preview + link de salir en /carta

## Resumen
El fix #152 agregó /api/preview/exit pero el único lugar donde ese link vivía era un callout en Notion — si alguien quedaba en preview sin saberlo, no tenía forma de notarlo ni de salir desde el sitio mismo. Ahora /carta muestra una barra visible siempre que Draft Mode esté activo ("👁️ Modo preview activo" o "⚠️ Hay cambios sin publicar" si aplica) con un link directo para salir, sin depender de volver a Notion.

## Test plan
- [x] pnpm build verde
- [ ] Redeploy manual + verificar visualmente el indicador y el link de salir en dev.dimoe.cl