### PR TITLE
fix(menu): Draft Mode no se reconoce en /carta sin prefijo de locale (fix #161)

### DIFF
--- a/app/api/preview/exit/route.ts
+++ b/app/api/preview/exit/route.ts
@@ -20,5 +20,5 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const draft = await draftMode()
   draft.disable()
 
-  return NextResponse.redirect(new URL('/carta', req.url))
+  return NextResponse.redirect(new URL('/es/carta', req.url))
 }

--- a/app/api/preview/route.ts
+++ b/app/api/preview/route.ts
@@ -20,5 +20,5 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const draft = await draftMode()
   draft.enable()
 
-  return NextResponse.redirect(new URL('/carta', req.url))
+  return NextResponse.redirect(new URL('/es/carta', req.url))
 }


### PR DESCRIPTION
Closes #161

## Tasks incluidas
- Closes #162 — fix: redirigir a /es/carta en las rutas de preview

## Resumen
Encontrado en pruebas E2E post-deploy: la ruta /carta (sin prefijo, default locale reescrita por middleware de next-intl) no reconoce la cookie de Draft Mode en Vercel, aunque /es/carta y /en/carta (con prefijo explícito) sí lo hacen — mismo código, mismo cookie, solo cambia la ruta de entrada. Reproducido consistentemente en producción, no reproducible en local. Fix: los redirects de /api/preview y /api/preview/exit apuntan ahora a /es/carta directamente, evitando la ruta rota.

## Test plan
- [x] pnpm build verde
- [ ] Redeploy manual + verificar E2E real: Ver preview → banner/indicador visible en /es/carta