### PR TITLE
chore(deploy): estabilizar pipeline post-auditoría de Fable (chore #168)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 .ruff_cache/
 node_modules/
 .next/
+.next-*/
 .nuxt/
 
 # Claude Code — skills y config local (no commitear en repo público)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,24 @@ pnpm install
 pnpm dev              # → http://localhost:39847
 ```
 
+## Deploy a producción (dev.dimoe.cl)
+
+**No hay auto-deploy configurado a Production.** Los Preview deployments sí se generan automáticos por cada push/PR, pero `dev.dimoe.cl` (el dominio real, target "Production" del proyecto Vercel) solo se actualiza con:
+
+```bash
+vercel deploy --prod --yes --force
+```
+
+**El `--force` es obligatorio** — sin él, se detectó al menos un caso donde el deploy reusó un manifest de rutas corrupto/desactualizado de un deployment anterior y una ruta nueva dio 404 en producción pese a compilar bien localmente.
+
+Tras cada deploy, correr el smoke test (de solo lectura, sin efectos secundarios):
+
+```bash
+node scripts/smoke-deploy.mjs
+```
+
+Si algo falla, no asumir que es el código nuevo — comparar contra `next dev`/`next start` local primero (varios bugs de esta clase solo se reproducen en Vercel, nunca en local).
+
 ## Convenciones
 
 ### Commits

--- a/scripts/smoke-deploy.mjs
+++ b/scripts/smoke-deploy.mjs
@@ -1,0 +1,61 @@
+/**
+ * Smoke test post-deploy para el flujo de publicación controlada (work-item #118).
+ * Corré esto después de cada `vercel deploy --prod` manual — es lo único que
+ * habría detectado los incidentes de producción encontrados en la auditoría
+ * (401 vs 404 en las rutas de publish/undo/preview, y contenido real en /carta).
+ *
+ * No usa el secret real ni dispara publish/undo — es de solo lectura, sin
+ * efectos secundarios, para poder correrlo tantas veces como haga falta.
+ *
+ * Uso: node scripts/smoke-deploy.mjs [base-url]
+ * Default base-url: https://dev.dimoe.cl
+ */
+
+const BASE_URL = process.argv[2] ?? 'https://dev.dimoe.cl'
+
+// Item real y estable del menú publicado — ajustar si cambia en Notion.
+const MENU_MARKER = 'Palitos di Agglio'
+
+const checks = []
+let failed = 0
+
+function check(name, ok, detail) {
+  checks.push({ name, ok, detail })
+  if (!ok) failed++
+  console.log(`${ok ? '✓' : '✗'}  ${name}${detail ? ' — ' + detail : ''}`)
+}
+
+async function fetchStatus(path) {
+  const res = await fetch(`${BASE_URL}${path}`, { redirect: 'manual' })
+  return res.status
+}
+
+async function fetchBody(path) {
+  const res = await fetch(`${BASE_URL}${path}`)
+  return res.text()
+}
+
+async function main() {
+  console.log(`🔎  Smoke test contra ${BASE_URL}\n`)
+
+  // Rutas de auth — sin secret, deben rechazar con 401 (no 404, no 500).
+  for (const path of ['/api/publish', '/api/undo', '/api/preview', '/api/preview-exit']) {
+    const status = await fetchStatus(path)
+    check(`${path} sin secret → 401`, status === 401, `status real: ${status}`)
+  }
+
+  // Contenido real publicado, visible sin cookie de preview.
+  const bareBody = await fetchBody('/carta')
+  check('/carta contiene el item marcador del menú', bareBody.includes(MENU_MARKER))
+
+  const esStatus = await fetchStatus('/es/carta')
+  check('/es/carta redirige (307) al path sin prefijo (comportamiento esperado de next-intl)', esStatus === 307, `status real: ${esStatus}`)
+
+  console.log(`\n${failed === 0 ? '✅  Todo OK' : `❌  ${failed} check(s) fallaron`}`)
+  process.exit(failed === 0 ? 0 : 1)
+}
+
+main().catch(err => {
+  console.error('❌  Error corriendo el smoke test:', err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #168

## Tasks incluidas
- Closes #169 — .gitignore + limpieza de cachés
- Closes #170 — verificación /carta vs /es/carta (riesgo cerrado, sin fix de código)
- Closes #171 — script de smoke-test post-deploy
- Closes #172 — investigación de deploy git-triggered (conexión ya existe, falta 1 chequeo de dashboard)

## Resumen
Acciones P0 de la auditoría independiente (Fable) sobre el work-item #118: se verificó con ediciones reales en Notion que la carta pública (`/carta`, sin prefijo de locale) sirve el contenido correcto tanto con como sin cookie de preview — el incidente de routing original ya no es reproducible. Se agregó un script de smoke-test de solo lectura para correr tras cada deploy manual, y se documentó el proceso en CLAUDE.md.

## Test plan
- [x] pnpm build verde
- [x] scripts/smoke-deploy.mjs corrido contra dev.dimoe.cl real, 6/6 verde
- [x] Verificación de paridad /carta vs /es/carta con ediciones reales y reversibles en Notion