### PR TITLE
fix(menu): hardening P1 post-auditoría — secret, no-op publish, timezone (fix #177)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ vercel deploy --prod --yes --force
 
 El `--force` es importante en ese caso puntual — se detectó al menos un caso donde un deploy reusó un manifest de rutas corrupto/desactualizado y una ruta nueva dio 404 en producción pese a compilar bien localmente.
 
+## ⚠️ Trampa conocida: ruta default de next-intl sin prefijo
+
+`i18n/routing.ts` usa `localePrefix: 'as-needed'` — el locale default (`es`) se sirve **sin prefijo** (`/carta`) vía un rewrite interno del middleware, mientras que las rutas con prefijo explícito (`/en/carta`, y `/es/carta` que en realidad redirige a `/carta`) hacen match directo. Esta asimetría causó dos incidentes de producción (solo reproducibles en Vercel, nunca en local) durante el desarrollo del work-item #118 — ambos se resolvieron, pero la asimetría estructural sigue ahí.
+
+**Regla:** cualquier página/ruta bajo el locale default sin prefijo que dependa de cookies, headers dinámicos o Draft Mode debe probarse explícitamente ahí (contra el dominio real de Vercel, no solo `next dev`/`next start` local) — no asumir que "funciona igual" que su versión prefijada.
+
 ## Convenciones
 
 ### Commits

--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -31,7 +31,6 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
 
   const publishedData = isPreview ? await getMenu(locale) : null;
   const hasUnpublishedChanges = isPreview && JSON.stringify(notionData) !== JSON.stringify(publishedData);
-  const previewExitUrl = `/api/preview-exit?secret=${process.env.PUBLISH_SECRET ?? ''}`;
 
   return (
     <main style={{ background: '#0D0B09' }}>
@@ -42,7 +41,7 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
               ? (isEn ? '⚠️ There are unpublished changes' : '⚠️ Hay cambios sin publicar')
               : (isEn ? '👁️ Preview mode active' : '👁️ Modo preview activo')}
           </span>
-          <a href={previewExitUrl} style={{ color: '#FFF7ED', textDecoration: 'underline', fontWeight: 700 }}>
+          <a href="/api/preview-exit" style={{ color: '#FFF7ED', textDecoration: 'underline', fontWeight: 700 }}>
             {isEn ? '🚪 Exit preview' : '🚪 Salir de preview'}
           </a>
         </div>

--- a/app/api/preview-exit/route.ts
+++ b/app/api/preview-exit/route.ts
@@ -1,22 +1,12 @@
-import { timingSafeEqual } from 'crypto'
 import { draftMode } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
-function secretsMatch(provided: string, expected: string): boolean {
-  const a = Buffer.from(provided)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return timingSafeEqual(a, b)
-}
-
+/**
+ * Sin autenticación a propósito: solo desactiva Draft Mode en el navegador
+ * que la invoca (borra la cookie __prerender_bypass propia), no expone ni
+ * modifica nada del lado del servidor.
+ */
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const secret = req.nextUrl.searchParams.get('secret') ?? ''
-  const expected = process.env.PUBLISH_SECRET ?? ''
-
-  if (!expected || !secretsMatch(secret, expected)) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
-  }
-
   const draft = await draftMode()
   draft.disable()
 

--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -88,19 +88,27 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 
-  const currentLive = await readBlobJson('menu-live.json')
+  try {
+    const currentLive = await readBlobJson('menu-live.json')
+    const fresh = await fetchNotionMenuRaw()
 
-  if (currentLive !== null) {
-    await writeBlobJson('menu-previous.json', currentLive)
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-    await writeBlobJson(`menu-snapshots/${timestamp}.json`, currentLive)
-    await pruneOldSnapshots()
+    if (currentLive !== null && JSON.stringify(fresh) === JSON.stringify(currentLive)) {
+      return htmlResponse('ℹ️ Sin cambios que publicar', 'El contenido de Notion es igual al ya publicado — no se modificó nada.')
+    }
+
+    if (currentLive !== null) {
+      await writeBlobJson('menu-previous.json', currentLive)
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+      await writeBlobJson(`menu-snapshots/${timestamp}.json`, currentLive)
+      await pruneOldSnapshots()
+    }
+
+    await writeBlobJson('menu-live.json', fresh)
+
+    revalidateTag('menu', 'max')
+
+    return htmlResponse('✅ Carta publicada', `${fresh.length} items actualizados.`)
+  } catch {
+    return htmlResponse('⚠️ No se pudo publicar', 'Hubo un problema al conectar con Notion o el almacenamiento. Probá de nuevo en unos minutos.')
   }
-
-  const fresh = await fetchNotionMenuRaw()
-  await writeBlobJson('menu-live.json', fresh)
-
-  revalidateTag('menu', 'max')
-
-  return htmlResponse('✅ Carta publicada', `${fresh.length} items actualizados.`)
 }

--- a/app/api/undo/route.ts
+++ b/app/api/undo/route.ts
@@ -34,19 +34,23 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 
-  const previous = await readBlobJson('menu-previous.json')
-  if (previous === null) {
-    return htmlResponse('⚠️ No hay versión anterior guardada', 'Todavía no se publicó ningún cambio para poder deshacerlo.')
+  try {
+    const previous = await readBlobJson('menu-previous.json')
+    if (previous === null) {
+      return htmlResponse('⚠️ No hay versión anterior guardada', 'Todavía no se publicó ningún cambio para poder deshacerlo.')
+    }
+
+    await put('menu-live.json', JSON.stringify(previous), {
+      access: 'private',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+      contentType: 'application/json',
+    })
+
+    revalidateTag('menu', 'max')
+
+    return htmlResponse('↩️ Cambios revertidos', 'La carta volvió a la versión anterior.')
+  } catch {
+    return htmlResponse('⚠️ No se pudo deshacer', 'Hubo un problema al conectar con el almacenamiento. Probá de nuevo en unos minutos.')
   }
-
-  await put('menu-live.json', JSON.stringify(previous), {
-    access: 'private',
-    addRandomSuffix: false,
-    allowOverwrite: true,
-    contentType: 'application/json',
-  })
-
-  revalidateTag('menu', 'max')
-
-  return htmlResponse('↩️ Cambios revertidos', 'La carta volvió a la versión anterior.')
 }

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -49,11 +49,17 @@ type NotionMenuPage = {
 
 const VALID_TABS = new Set<string>(['ENTRADAS', 'PIZZAS', 'FONDOS', 'POSTRES', 'BAR', 'VINOS', 'SEMANAL'])
 
+// El servidor de Vercel corre en UTC — Chile es UTC-3/-4, así que el día de
+// la semana hay que calcularlo en su propia timezone, no con Date.getDay().
+const WEEKDAY_TO_KEY = { Sun: 'D', Mon: 'L', Tue: 'M', Wed: 'W', Thu: 'J', Fri: 'V', Sat: 'S' } as const
+const CHILE_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', { timeZone: 'America/Santiago', weekday: 'short' })
+
 function parseMenuPages(
   pages: NotionMenuPage[],
   isEn: boolean,
 ): Record<MenuTab, MenuGroup[]> {
   const byTab = new Map<MenuTab, Map<string, MenuItem[]>>()
+  const todayKey = WEEKDAY_TO_KEY[CHILE_WEEKDAY_FORMATTER.format(new Date()) as keyof typeof WEEKDAY_TO_KEY]
 
   for (const page of pages) {
     const p = page.properties
@@ -67,9 +73,7 @@ function parseMenuPages(
     const groups = byTab.get(menuTab)!
     if (!groups.has(subcat)) groups.set(subcat, [])
 
-    // Filtro de días: 0=Dom 1=Lun 2=Mar 3=Mié 4=Jue 5=Vie 6=Sáb
-    const DAY_KEYS = ['D', 'L', 'M', 'W', 'J', 'V', 'S'] as const
-    const todayKey = DAY_KEYS[new Date().getDay()]
+    // Filtro de días
     const anyDaySet = (['L', 'M', 'W', 'J', 'V', 'S', 'D'] as const).some(k => p[k]?.checkbox === true)
     if (anyDaySet && !p[todayKey]?.checkbox) continue
 


### PR DESCRIPTION
Closes #177

## Tasks incluidas
- Closes #178 — quitar secret innecesario de /api/preview-exit
- Closes #179 — publish no-op sin cambios + try/catch amigable
- Closes #180 — timezone America/Santiago en filtro de días
- Closes #181 — docs de la trampa de rutas bare vs. prefijadas

## Resumen
Acciones P1 de la auditoría independiente (Fable) sobre el work-item #118. Dos hallazgos de seguridad reales: `/api/preview-exit` no necesitaba autenticación (solo borra una cookie propia), y `/api/publish` (GET con efectos secundarios) podía rotar snapshots innecesariamente ante un "unfurl" de link accidental, destruyendo el undo — ahora es no-op si el contenido no cambió. Se agregó manejo de errores legible en ambas rutas. Se corrigió un bug real de timezone (UTC vs. Chile) en el filtro de días activos del menú. Se documentó la asimetría de rutas de next-intl como advertencia para el futuro.

## Test plan
- [x] pnpm build verde
- [x] Publish no-op verificado con timestamps reales de Blob (sin cambios no rota, con cambios sí rota)
- [x] Timezone verificado con simulación del escenario exacto del bug (viernes noche Chile / sábado UTC)
- [x] Link de Notion actualizado sin secret, verificado