### PR TITLE
fix(menu): paginación de preview + banner sin falso positivo + VINOS/SEMANAL desde Notion (fix #188)

### DIFF
--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -25,6 +25,7 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
   const isEn = locale === 'en';
   const { isEnabled: isPreview } = await draftMode();
   const notionData = isPreview ? await getMenuPreview(locale) : await getMenu(locale);
+  const previewFetchFailed = isPreview && notionData === null;
   const menuData = notionData
     ? {
         ...notionData,
@@ -34,16 +35,18 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
     : FALLBACK_MENU;
 
   const publishedData = isPreview ? await getMenu(locale) : null;
-  const hasUnpublishedChanges = isPreview && JSON.stringify(notionData) !== JSON.stringify(publishedData);
+  const hasUnpublishedChanges = isPreview && !previewFetchFailed && JSON.stringify(notionData) !== JSON.stringify(publishedData);
 
   return (
     <main style={{ background: '#0D0B09' }}>
       {isPreview && (
-        <div style={{ background: hasUnpublishedChanges ? '#B45309' : '#3F3F46', color: '#FFF7ED', textAlign: 'center', padding: '10px 16px', fontSize: '14px', fontWeight: 600, display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'center', gap: '8px' }}>
+        <div style={{ background: previewFetchFailed ? '#7F1D1D' : hasUnpublishedChanges ? '#B45309' : '#3F3F46', color: '#FFF7ED', textAlign: 'center', padding: '10px 16px', fontSize: '14px', fontWeight: 600, display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'center', gap: '8px' }}>
           <span>
-            {hasUnpublishedChanges
-              ? (isEn ? '⚠️ There are unpublished changes' : '⚠️ Hay cambios sin publicar')
-              : (isEn ? '👁️ Preview mode active' : '👁️ Modo preview activo')}
+            {previewFetchFailed
+              ? (isEn ? '⚠️ Could not connect to Notion — try again' : '⚠️ No se pudo conectar con Notion — reintentá')
+              : hasUnpublishedChanges
+                ? (isEn ? '⚠️ There are unpublished changes' : '⚠️ Hay cambios sin publicar')
+                : (isEn ? '👁️ Preview mode active' : '👁️ Modo preview activo')}
           </span>
           <a href="/api/preview-exit" style={{ color: '#FFF7ED', textDecoration: 'underline', fontWeight: 700 }}>
             {isEn ? '🚪 Exit preview' : '🚪 Salir de preview'}

--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -26,7 +26,11 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
   const { isEnabled: isPreview } = await draftMode();
   const notionData = isPreview ? await getMenuPreview(locale) : await getMenu(locale);
   const menuData = notionData
-    ? { ...notionData, VINOS: FALLBACK_MENU.VINOS, SEMANAL: FALLBACK_MENU.SEMANAL }
+    ? {
+        ...notionData,
+        VINOS: notionData.VINOS.length > 0 ? notionData.VINOS : FALLBACK_MENU.VINOS,
+        SEMANAL: notionData.SEMANAL.length > 0 ? notionData.SEMANAL : FALLBACK_MENU.SEMANAL,
+      }
     : FALLBACK_MENU;
 
   const publishedData = isPreview ? await getMenu(locale) : null;

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -149,25 +149,34 @@ export async function getMenuPreview(
   const isEn = locale === 'en'
 
   try {
-    const res = await fetch(`${NOTION_API}/databases/${dbId}/query`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'Notion-Version': NOTION_VERSION,
-      },
-      body: JSON.stringify({
-        filter: { property: 'Activo', checkbox: { equals: true } },
-        sorts: [{ property: 'Orden', direction: 'ascending' }],
-        page_size: 200,
-      }),
-      cache: 'no-store',
-    })
+    const pages: NotionMenuPage[] = []
+    let cursor: string | undefined
 
-    if (!res.ok) return null
+    do {
+      const res = await fetch(`${NOTION_API}/databases/${dbId}/query`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'Notion-Version': NOTION_VERSION,
+        },
+        body: JSON.stringify({
+          filter: { property: 'Activo', checkbox: { equals: true } },
+          sorts: [{ property: 'Orden', direction: 'ascending' }],
+          page_size: 100,
+          ...(cursor ? { start_cursor: cursor } : {}),
+        }),
+        cache: 'no-store',
+      })
 
-    const data = await res.json() as { results: NotionMenuPage[]; has_more: boolean }
-    return parseMenuPages(data.results, isEn)
+      if (!res.ok) return null
+
+      const data = await res.json() as { results: NotionMenuPage[]; has_more: boolean; next_cursor: string | null }
+      pages.push(...data.results)
+      cursor = data.has_more ? (data.next_cursor ?? undefined) : undefined
+    } while (cursor)
+
+    return parseMenuPages(pages, isEn)
   } catch {
     return null
   }


### PR DESCRIPTION
Closes #188

## Tasks incluidas
- Closes #189 — chore: poblar VINOS y SEMANAL en Notion
- Closes #190 — fix: quitar override de VINOS/SEMANAL en page.tsx
- Closes #191 — fix: paginación en getMenuPreview
- Closes #192 — fix: banner distingue error de Notion de cambios reales sin publicar

## Resumen
- VINOS y SEMANAL ahora muestran contenido real de Notion en `/carta` (antes siempre se pisaban con `FALLBACK_MENU`); solo caen a fallback si la categoría queda vacía.
- `getMenuPreview()` pagina igual que `fetchNotionMenuRaw()` (loop `has_more`/`next_cursor`), evitando truncar items cuando el menú supera una página.
- El banner de preview distingue un error real de conexión con Notion ("⚠️ No se pudo conectar con Notion — reintentá") de un estado de "hay cambios sin publicar", que antes eran indistinguibles.

## Test plan
- [x] `pnpm build` verde
- [x] Verificado E2E real contra Notion/Blob de producción: VINOS y SEMANAL muestran contenido real ("Carménère", "Tarapacá", "Viu Manent", "Reineta", "salmón")
- [x] Publish confirmado sin truncar paginación (89 items: 62+23+4)
- [x] Banner "Modo preview activo" (sin cambios pendientes) verificado
- [x] Banner "⚠️ No se pudo conectar con Notion" verificado simulando token inválido