### PR TITLE
fix(menu): fallback dinámico de subtabs BAR en vez de Otros (fix #224)

### DIFF
--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -52,22 +52,23 @@ const TAB_SEPARATOR_PHOTO: Partial<Record<MenuTab, { src: string; pos: string }>
 };
 
 // Subtabs de navegación dentro de un tab activo — mapea group.name → bucket.
-// Grupos sin entrada caen en "Otros" (no desaparecen silenciosamente).
-// Poblado por tarea: BAR (#107), VINOS (#108). Vacío = sin subtabs, comportamiento actual.
+// Solo para agrupar deliberadamente varias subcategorías bajo un mismo tab
+// (ej. Spritz + Sours + Coctelería Clásica → "Cócteles"). Una subcategoría
+// que no está acá NO cae en un cajón genérico — se muestra con su propio
+// nombre (ver fallback en `presentBuckets` más abajo), así que agregar una
+// subcategoría nueva en Notion no requiere tocar este archivo.
 const TAB_SUBTABS: Partial<Record<MenuTab, Record<string, string>>> = {
   BAR: {
     'Happy Hour': 'Happy Hour',
-    'Gin Frutal': 'Cócteles',
     'Coctelería de la Casa': 'Cócteles',
     'Spritz': 'Cócteles',
     'Sours': 'Cócteles',
     'Coctelería Clásica': 'Cócteles',
-    'Cervezas Artesanales — La Casona': 'Cerveza',
-    'Vinos y Espumantes': 'Vino y Espumante',
-    'Sin Alcohol': 'Sin Alcohol',
+    'Cervezas': 'Cerveza',
+    'Coctelería sin alcohol': 'Sin Alcohol',
     'Jugos y Bebidas': 'Sin Alcohol',
+    'Vinos y Espumantes': 'Vino y Espumante',
     'Tragos': 'Destilados',
-    'Shots': 'Destilados',
   },
   VINOS: {
     'Sauvignon Blanc': 'Blancos',
@@ -115,14 +116,18 @@ export default function Menu({ menu }: Props) {
   // para no ofrecer un subtab que lleve a una sección vacía si el contenido real (Notion)
   // todavía no tiene grupos para ese bucket.
   const subtabConfig = active ? TAB_SUBTABS[active] : undefined;
+  // Fallback: si la subcategoría no está agrupada explícitamente, se usa su
+  // propio nombre — Notion ya dice a qué subcategoría pertenece un ítem, no
+  // hace falta un bucket "Otros" genérico ni tocar código para que aparezca.
+  const bucketFor = (name?: string) => subtabConfig?.[name ?? ''] ?? name ?? 'Otros';
   const presentBuckets = subtabConfig
-    ? groups.map(g => subtabConfig[g.name ?? ''] ?? 'Otros')
+    ? groups.map(g => bucketFor(g.name))
     : [];
   const subtabLabels = subtabConfig
     ? ['Todos', ...Array.from(new Set(presentBuckets))]
     : [];
   const groupsInSubtabs = subtabConfig
-    ? groups.filter(g => activeSubtab === 'Todos' || (subtabConfig[g.name ?? ''] ?? 'Otros') === activeSubtab)
+    ? groups.filter(g => activeSubtab === 'Todos' || bucketFor(g.name) === activeSubtab)
     : groups;
 
   // Punto de corte para el separador de foto: después del grupo donde se acumulan

--- a/lib/menu-fallback.ts
+++ b/lib/menu-fallback.ts
@@ -117,9 +117,9 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
         { name: 'Schop 500cc', desc: 'Variedades', price: 3700, note: 'Normal $4.500' },
       ],
     },
-    // 2. Gin Frutal — protagonista visual
+    // 2. Gin — protagonista visual (bucket propio, no agrupado con Cócteles)
     {
-      name: 'Gin Frutal',
+      name: 'Gin',
       subtitle: '$7.500 c/u',
       items: [
         { name: 'Berries', price: 7500 },
@@ -189,7 +189,7 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
     },
     // 7. Cervezas
     {
-      name: 'Cervezas Artesanales — La Casona',
+      name: 'Cervezas',
       items: [
         { name: 'Litro Degustación', desc: '3 schops 350cc a tu gusto de las cervezas del día', price: 8900 },
         { name: 'Calafate Premium 500cc', price: 5000 },
@@ -251,16 +251,9 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
         { name: 'Amaretto', desc: 'Bajativo', price: 4000 },
         { name: 'Manzanilla', desc: 'Bajativo', price: 3800 },
         { name: 'Menta', desc: 'Bajativo', price: 3500 },
-      ],
-    },
-    // 12. Shots
-    {
-      name: 'Shots',
-      subtitle: '$3.000 c/u',
-      items: [
-        { name: 'Tequila José Cuervo', price: 3000 },
-        { name: 'Jagermeister', price: 3000 },
-        { name: 'Fireball', price: 3000 },
+        { name: 'Tequila José Cuervo (Shot)', desc: 'Shot', price: 3000 },
+        { name: 'Jagermeister (Shot)', desc: 'Shot', price: 3000 },
+        { name: 'Fireball (Shot)', desc: 'Shot', price: 3000 },
       ],
     },
   ],


### PR DESCRIPTION
Closes #224

## Tasks incluidas
- Closes #225 — fix: fallback dinámico de subtabs BAR

## Resumen
- Las subcategorías de BAR agregadas en #205 (Gin, Cervezas, Coctelería sin alcohol) caían en el subtab genérico "Otros" porque el mapeo `TAB_SUBTABS.BAR` estaba hardcodeado y desactualizado.
- En vez de parchear las 3 claves, se cambió el fallback: si una subcategoría no está agrupada explícitamente, se muestra con su propio nombre (el que ya define Notion) en vez de cualquier bucket genérico. Así, agregar una subcategoría nueva en Notion no requiere tocar este archivo.

## Test plan
- [x] `pnpm build` verde
- [x] Simulación con datos reales de Notion (BAR): ninguna subcategoría activa cae en "Otros"
- [ ] Verificación visual en preview de Vercel del PR