### PR TITLE
fix(carta): ajustes visuales de /carta — fotos y tamaño de notas (fix #220)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -73,7 +73,7 @@ body {
   background-attachment: fixed;
 }
 
-/* Separador de foto full-bleed dentro del contenido de /carta — más bajo en mobile */
+/* Separador de foto dentro del contenido de /carta, ancho limitado a la columna — más bajo en mobile */
 .menu-separator { height: 220px; }
 @media (max-width: 767px) {
   .menu-separator { height: 140px; }

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -443,7 +443,7 @@ export default function Menu({ menu }: Props) {
                             </p>
                           )}
                           {item.note && (
-                            <p style={{ fontSize: '11px', color: 'rgba(193,122,59,0.55)', margin: '3px 0 0', fontStyle: 'italic' }}>
+                            <p style={{ fontSize: '14px', lineHeight: 1.65, color: 'rgba(193,122,59,0.55)', margin: '3px 0 0', fontStyle: 'italic' }}>
                               {item.note}
                             </p>
                           )}

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -463,14 +463,13 @@ export default function Menu({ menu }: Props) {
 
                 </div>
 
-                {/* Foto real full-bleed — rompe la lista a mitad de sección, ritmo editorial del PDF */}
+                {/* Foto real, ritmo editorial del PDF — limitada al ancho del contenido para no perder resolución en desktop */}
                 {gi === sepIndex && sepPhoto && (
                   <div className="menu-separator" style={{
-                    position: 'relative', width: '100vw', marginLeft: 'calc(50% - 50vw)', marginRight: 'calc(50% - 50vw)',
-                    overflow: 'hidden', marginTop: '4px', marginBottom: '44px',
+                    position: 'relative', overflow: 'hidden', marginTop: '4px', marginBottom: '44px',
                     borderTop: '1px solid rgba(193,122,59,0.25)', borderBottom: '1px solid rgba(193,122,59,0.25)',
                   }}>
-                    <Image src={sepPhoto.src} alt={TAB_DISPLAY[active]} fill sizes="100vw" quality={90}
+                    <Image src={sepPhoto.src} alt={TAB_DISPLAY[active]} fill sizes="(max-width: 800px) 100vw, 760px" quality={90}
                       data-photo={`separator-${active.toLowerCase()}`}
                       style={{ objectFit: 'cover', objectPosition: sepPhoto.pos }} />
                     <div style={{ position: 'absolute', inset: 0, background: `linear-gradient(to bottom, ${bg}00 0%, ${bg}55 100%)` }} />

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -268,7 +268,7 @@ export default function Menu({ menu }: Props) {
           Solo la foto del tab activo se monta — evita descargar las 7 fotos
           a la vez en la carga inicial. El crossfade lo da AnimatePresence.
       ──────────────────────────────────────────────────────────────────────── */}
-      <div style={{ position: 'relative', width: '100%', height: '300px', overflow: 'hidden' }}>
+      <div style={{ position: 'relative', width: '100%', height: '240px', overflow: 'hidden' }}>
         <AnimatePresence>
           <motion.div
             key={active}


### PR DESCRIPTION
Closes #220

## Tasks incluidas
- Closes #221 — fix: Limitar la foto separadora al ancho del contenido (evitar pixelado en desktop)
- Closes #222 — fix: Reducir la altura del banner de foto por sección
- Closes #223 — fix: Igualar tamaño de la nota/subdescripción de item a la descripción principal

## Resumen
- La foto full-bleed que corta la lista a mitad de sección ya no se sale del contenedor (`width:100vw` → ancho de contenido ~760px) — se veía pixelada en desktop ancho por falta de resolución fuente.
- El banner de foto arriba de cada sección activa pasa de 300px a 240px de alto.
- La nota/subdescripción de un item (ej. "Opción: pollo, carne mechada, tocino o champiñones +$1.000") pasa de 11px a 14px, igual que la descripción principal — pedido reiterado por clientes que la encontraban ilegible en mobile.

## Test plan
- [x] `pnpm build` + `tsc --noEmit` verdes
- [x] Playwright 40-41/41 (1 fallo de cold-start no relacionado, confirmado en re-run aislado)
- [x] Verificado visualmente en mobile (390px) y desktop (1280px/1920px) para los 3 cambios