### PR TITLE
fix(api): reportar diff real en /api/publish en vez del total (fix #228)

### DIFF
--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -59,6 +59,36 @@ async function pruneOldSnapshots(): Promise<void> {
   if (toDelete.length > 0) await del(toDelete)
 }
 
+type NotionRawPage = { id: string }
+
+function diffMenuPages(before: unknown[] | null, after: unknown[]): { added: number; modified: number; removed: number } {
+  const beforeById = new Map((before ?? []).map(p => [(p as NotionRawPage).id, p]))
+  const afterIds = new Set(after.map(p => (p as NotionRawPage).id))
+
+  let added = 0
+  let modified = 0
+  for (const p of after) {
+    const prev = beforeById.get((p as NotionRawPage).id)
+    if (!prev) added++
+    else if (JSON.stringify(prev) !== JSON.stringify(p)) modified++
+  }
+
+  let removed = 0
+  for (const id of beforeById.keys()) {
+    if (!afterIds.has(id)) removed++
+  }
+
+  return { added, modified, removed }
+}
+
+function formatDiff({ added, modified, removed }: { added: number; modified: number; removed: number }): string {
+  const parts: string[] = []
+  if (added) parts.push(`${added} agregado${added === 1 ? '' : 's'}`)
+  if (modified) parts.push(`${modified} modificado${modified === 1 ? '' : 's'}`)
+  if (removed) parts.push(`${removed} eliminado${removed === 1 ? '' : 's'}`)
+  return parts.join(', ') || 'sin cambios detectados'
+}
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const secret = req.nextUrl.searchParams.get('secret') ?? ''
   const expected = process.env.PUBLISH_SECRET ?? ''
@@ -86,7 +116,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     revalidateTag('menu', 'max')
 
-    return htmlResponse('✅ Carta publicada', `${fresh.length} items actualizados.`)
+    const diff = formatDiff(diffMenuPages(currentLive, fresh))
+    return htmlResponse('✅ Carta publicada', `${fresh.length} items en el menú — ${diff}.`)
   } catch {
     return htmlResponse('⚠️ No se pudo publicar', 'Hubo un problema al conectar con Notion o el almacenamiento. Probá de nuevo en unos minutos.')
   }


### PR DESCRIPTION
Closes #228

## Tasks incluidas
- Closes #229

## Resumen
- El dev cambió 1 campo de 1 ítem en Notion y `/api/publish` reportó "164 items actualizados" (el total de páginas activas, no el diff real) — confusión sobre si algo se rompió.
- Se agrega un diff por `id` entre el snapshot previo y el nuevo antes de publicar, reportando agregados/modificados/eliminados reales.
- Verificado con diff manual de snapshots reales de Notion: el caso reportado (1 campo cambiado) ahora mostraría "1 modificado" en vez de "164 items actualizados".

## Test plan
- [x] `pnpm build` verde
- [x] Lógica de diff verificada con 3 casos (1 modificado, primera publicación, agregado+eliminado)
- [ ] Verificación en preview de Vercel: cambiar 1 campo en Notion y confirmar el mensaje de /api/publish