### PR TITLE
fix(carta): limitar banner de foto por sección al ancho del contenido

### DIFF
--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -273,7 +273,7 @@ export default function Menu({ menu }: Props) {
           Solo la foto del tab activo se monta — evita descargar las 7 fotos
           a la vez en la carga inicial. El crossfade lo da AnimatePresence.
       ──────────────────────────────────────────────────────────────────────── */}
-      <div style={{ position: 'relative', width: '100%', height: '240px', overflow: 'hidden' }}>
+      <div style={{ position: 'relative', maxWidth: '760px', width: '100%', margin: '0 auto', height: '240px', overflow: 'hidden' }}>
         <AnimatePresence>
           <motion.div
             key={active}
@@ -288,7 +288,7 @@ export default function Menu({ menu }: Props) {
               alt={TAB_DISPLAY[active]}
               data-photo={`banner-${active.toLowerCase()}`}
               fill
-              sizes="100vw"
+              sizes="(max-width: 800px) 100vw, 760px"
               quality={90}
               priority
               style={{ objectFit: 'cover', objectPosition: TAB_PHOTO_POS[active] }}


### PR DESCRIPTION
## Resumen
El banner horizontal de foto arriba de cada sección activa de /carta era `width:100%` sin límite — a 1920px se veía pixelado por falta de resolución fuente. Mismo problema y mismo fix que ya se aplicó al separador de foto en #220/#221: limitarlo a `maxWidth: 760px` (ancho de la columna de contenido).

Cambio simple, un solo archivo, sin cambio de comportamiento — verificado con tsc + captura visual en 1920px y mobile. Sin suite Playwright completo por pedido explícito del dev (fix urgente).

## Test plan
- [x] `tsc --noEmit` limpio
- [x] Verificado visualmente en 1920px (ya no pixelado) y mobile 390px (sin regresión)