### PR TITLE
fix(api): hardening pre-corte de /api/contact (logo URL, HTML injection, header injection)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -21,6 +21,10 @@ function escapeHtml(str: string): string {
   return str.replace(/[&<>"']/g, c => HTML_ESCAPES[c]);
 }
 
+function sanitizeHeaderValue(str: string): string {
+  return str.replace(/[\r\n]+/g, ' ').trim();
+}
+
 function notificationHtml(nombreRaw: string, emailRaw: string, telefonoRaw: string | null, mensajeRaw: string, marketing: boolean, tipo: ContactTipo, origen: ContactOrigen) {
   const nombre = escapeHtml(nombreRaw);
   const email = escapeHtml(emailRaw);
@@ -198,7 +202,7 @@ export async function POST(req: NextRequest) {
         from: FROM,
         to: DESTINATION,
         replyTo: email,
-        subject: `[${tipoFinal}] Mensaje de ${nombre}${telefono ? ` · ${telefono}` : ''} — DiMOE`,
+        subject: `[${tipoFinal}] Mensaje de ${sanitizeHeaderValue(nombre)}${telefono ? ` · ${sanitizeHeaderValue(telefono)}` : ''} — DiMOE`,
         html: notificationHtml(nombre, email, telefono ?? null, mensaje, !!marketing_consent, tipoFinal, origenFinal),
       }),
       resend.emails.send({

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -13,7 +13,7 @@ function deviceFromUserAgent(req: NextRequest): 'Mobile' | 'Desktop' {
 
 const DESTINATION = 'contacto@dimoe.cl';
 const FROM = 'DiMOE <contacto@dimoe.cl>';
-const LOGO_URL = 'https://dev.dimoe.cl/images/logo-transparent.png';
+const LOGO_URL = 'https://dimoe.cl/images/logo-transparent.png';
 const LOGO_HEADER = `<tr><td style="background:#0D0B09;padding:28px 40px;text-align:center"><img src="${LOGO_URL}" alt="DiMOE" height="42" style="display:block;margin:0 auto;height:42px;width:auto"></td></tr>`;
 
 function notificationHtml(nombre: string, email: string, telefono: string | null, mensaje: string, marketing: boolean, tipo: ContactTipo, origen: ContactOrigen) {

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -16,7 +16,16 @@ const FROM = 'DiMOE <contacto@dimoe.cl>';
 const LOGO_URL = 'https://dimoe.cl/images/logo-transparent.png';
 const LOGO_HEADER = `<tr><td style="background:#0D0B09;padding:28px 40px;text-align:center"><img src="${LOGO_URL}" alt="DiMOE" height="42" style="display:block;margin:0 auto;height:42px;width:auto"></td></tr>`;
 
-function notificationHtml(nombre: string, email: string, telefono: string | null, mensaje: string, marketing: boolean, tipo: ContactTipo, origen: ContactOrigen) {
+const HTML_ESCAPES: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+function escapeHtml(str: string): string {
+  return str.replace(/[&<>"']/g, c => HTML_ESCAPES[c]);
+}
+
+function notificationHtml(nombreRaw: string, emailRaw: string, telefonoRaw: string | null, mensajeRaw: string, marketing: boolean, tipo: ContactTipo, origen: ContactOrigen) {
+  const nombre = escapeHtml(nombreRaw);
+  const email = escapeHtml(emailRaw);
+  const telefono = telefonoRaw ? escapeHtml(telefonoRaw) : null;
+  const mensaje = escapeHtml(mensajeRaw);
   const fecha = new Date().toLocaleString('es-CL', { timeZone: 'America/Santiago', dateStyle: 'full', timeStyle: 'short' });
   return `<!DOCTYPE html>
 <html lang="es">
@@ -87,7 +96,8 @@ function notificationHtml(nombre: string, email: string, telefono: string | null
 </html>`;
 }
 
-function confirmationHtml(nombre: string, caso: boolean) {
+function confirmationHtml(nombreRaw: string, caso: boolean) {
+  const nombre = escapeHtml(nombreRaw);
   const bodyHtml = caso
     ? `<p style="margin:0 0 16px;font-family:Georgia,serif;font-size:18px;color:#1A1410;line-height:1.5">Hola, ${nombre}.</p>
        <p style="margin:0 0 12px;font-family:Arial,sans-serif;font-size:15px;color:#5A4A3F;line-height:1.7">Nuestro equipo de servicio al cliente ya está revisando tu mensaje personalmente y te responderemos dentro de las próximas 24-48 horas.</p>


### PR DESCRIPTION
## Resumen
Tres bugs encontrados durante QA pre-corte de DNS (dev.dimoe.cl -> dimoe.cl), probando el formulario de contacto en vivo con combinaciones reales:

- #240 - LOGO_URL en los emails apuntaba hardcodeado a dev.dimoe.cl en vez de dimoe.cl.
- #241 - nombre/email/telefono/mensaje se interpolaban sin escapar en el HTML del email de notificacion/confirmacion - riesgo de HTML injection en el correo que recibe admin@dimoe.cl.
- #242 - nombre/telefono sin sanitizar en el subject del email - riesgo de header injection (CR/LF) en el email saliente.

## Plan de pruebas
- [x] tsc --noEmit limpio en cada commit
- [x] Escapado de HTML verificado con payload de prueba (script tag, comillas, ampersand) - sanitiza correctamente
- [x] 5 envios reales del formulario contra dev.dimoe.cl (combinaciones Home/Atencion Cliente x Consulta/Sugerencia/Reclamo) confirmados recibidos por el cliente y por admin@dimoe.cl, y contacto creado en Notion

Closes #240
Closes #241
Closes #242