### PR TITLE
fix(carta): reestructurar subtabs BAR/VINOS, navegación y bug de días

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tsconfig.tsbuildinfo
 
 # Backups locales de Notion (scripts/backup-menu.mjs) — no commitear al repo
 backups/
+.claude-credentials

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -4,6 +4,7 @@ import { Fragment, useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslations, useLocale } from 'next-intl';
+import { Link } from '@/i18n/navigation';
 import type { MenuTab, MenuGroup } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
 import { typography } from '@/lib/typography';
@@ -69,21 +70,26 @@ const TAB_SUBTABS: Partial<Record<MenuTab, Record<string, string>>> = {
     'Coctelería sin alcohol': 'Sin Alcohol',
     'Jugos y Bebidas': 'Sin Alcohol',
     'Vinos y Espumantes': 'Vino y Espumante',
-    'Tragos': 'Destilados',
+    // Destilados — antes un solo grupo "Tragos" con desc redundante (repetía
+    // el tipo de licor en cada ítem); ahora una Subcategoría real por tipo,
+    // todas agrupadas bajo el mismo subtab "Destilados".
+    'Pisco': 'Destilados',
+    'Ron': 'Destilados',
+    'Whisky': 'Destilados',
+    'Ginebra': 'Destilados',
+    'Tequila': 'Destilados',
+    'Bajativo': 'Destilados',
+    'Shots': 'Destilados',
   },
-  VINOS: {
-    'Sauvignon Blanc': 'Blancos',
-    'Chardonnay': 'Blancos',
-    'Carménère': 'Tintos',
-    'Cabernet Sauvignon': 'Tintos',
-    'Merlot': 'Tintos',
-    'Ensamblajes': 'Ensamblajes y Dulce',
-    'Dulce': 'Ensamblajes y Dulce',
-  },
+  // Objeto vacío (no undefined): activa el bucketing pero sin agrupar nada
+  // explícito, así cada Subcategoría real (Espumante, Carménère, Cabernet
+  // Sauvignon, Merlot, Blanco, ...) aparece como su propio subtab — mismo
+  // patrón de fallback-a-nombre-propio que #224 aplicó en BAR.
+  VINOS: {},
 };
 
 const TAB_DISPLAY: Record<MenuTab, string> = {
-  ENTRADAS: 'ANTIPASTI',
+  ENTRADAS: 'ENTRADAS',
   PIZZAS:   'PIZZAS',
   FONDOS:   'FONDOS',
   POSTRES:  'DOLCE',
@@ -324,7 +330,7 @@ export default function Menu({ menu }: Props) {
           )}
         </div>
 
-        <MenuSubtabs labels={subtabLabels} active={activeSubtab} onChange={setActiveSubtab} bg={bg} />
+        <MenuSubtabs labels={subtabLabels} active={activeSubtab} onChange={setActiveSubtab} />
 
         <AnimatePresence mode="wait">
           <motion.div key={`${active}-${activeSubtab}`}
@@ -337,6 +343,9 @@ export default function Menu({ menu }: Props) {
               const isSemanaleChef = active === 'SEMANAL' && group.name === 'Menú del Chef';
               const noDesc = group.items.every(i => !i.desc);
               const isCompact = noDesc && group.items.length > 2;
+              // Puntero "ver detalle en Vinos" — el único ítem de este grupo en BAR
+              // debe navegar de verdad a la tab VINOS, no quedar como texto suelto.
+              const isVinosPointer = active === 'BAR' && group.name === 'Vinos y Espumantes';
 
               return (
                 <Fragment key={gi}>
@@ -403,60 +412,73 @@ export default function Menu({ menu }: Props) {
                     gridTemplateColumns: 'repeat(auto-fill, minmax(168px, 1fr))',
                     gap: '2px 20px',
                   } : {}}>
-                    {group.items.map((item, ii) => (
-                      <div key={ii} style={{
-                        display: 'flex',
-                        alignItems: isCompact ? 'baseline' : 'flex-start',
-                        justifyContent: 'space-between',
-                        gap: isCompact ? '8px' : '16px',
-                        padding: isCompact ? '7px 0' : '16px 0',
-                        borderBottom: isCompact ? 'none' : '1px solid rgba(242,237,228,0.06)',
-                        opacity: isKids ? 0.62 : 1,
-                      }}>
-                        <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{
-                            display: 'flex', alignItems: 'center', gap: '7px', flexWrap: 'wrap',
-                            marginBottom: (!isCompact && item.desc) ? '5px' : 0,
-                          }}>
-                            <span style={{
-                              ...(isCompact ? typography.itemNameCompact : typography.itemName),
-                              color: '#F2EDE4',
+                    {group.items.map((item, ii) => {
+                      const row = (
+                        <div style={{
+                          display: 'flex',
+                          alignItems: isCompact ? 'baseline' : 'flex-start',
+                          justifyContent: 'space-between',
+                          gap: isCompact ? '8px' : '16px',
+                          padding: isCompact ? '7px 0' : '16px 0',
+                          borderBottom: isCompact ? 'none' : '1px solid rgba(242,237,228,0.06)',
+                          opacity: isKids ? 0.62 : 1,
+                        }}>
+                          <div style={{ flex: 1, minWidth: 0 }}>
+                            <div style={{
+                              display: 'flex', alignItems: 'center', gap: '7px', flexWrap: 'wrap',
+                              marginBottom: (!isCompact && item.desc) ? '5px' : 0,
                             }}>
-                              {item.name}
-                            </span>
-                            {item.badge && (
                               <span style={{
-                                ...typography.badge,
-                                color: '#C17A3B',
-                                border: '1px solid rgba(193,122,59,0.4)',
-                                borderRadius: '100px', padding: '2px 8px', whiteSpace: 'nowrap',
+                                ...(isCompact ? typography.itemNameCompact : typography.itemName),
+                                color: isVinosPointer ? '#C17A3B' : '#F2EDE4',
                               }}>
-                                {item.badge}
+                                {item.name}
                               </span>
+                              {item.badge && (
+                                <span style={{
+                                  ...typography.badge,
+                                  color: '#C17A3B',
+                                  border: '1px solid rgba(193,122,59,0.4)',
+                                  borderRadius: '100px', padding: '2px 8px', whiteSpace: 'nowrap',
+                                }}>
+                                  {item.badge}
+                                </span>
+                              )}
+                            </div>
+                            {!isCompact && item.desc && (
+                              <p style={{ ...typography.body, color: isVinosPointer ? 'rgba(193,122,59,0.75)' : 'rgba(242,237,228,0.48)', margin: 0 }}>
+                                {item.desc}
+                              </p>
+                            )}
+                            {item.note && (
+                              <p style={{ ...typography.note, color: 'rgba(193,122,59,0.55)', margin: '3px 0 0' }}>
+                                {item.note}
+                              </p>
                             )}
                           </div>
-                          {!isCompact && item.desc && (
-                            <p style={{ ...typography.body, color: 'rgba(242,237,228,0.48)', margin: 0 }}>
-                              {item.desc}
-                            </p>
-                          )}
-                          {item.note && (
-                            <p style={{ ...typography.note, color: 'rgba(193,122,59,0.55)', margin: '3px 0 0' }}>
-                              {item.note}
-                            </p>
+                          {fmt(item.price) != null && (
+                            <span style={{
+                              flexShrink: 0,
+                              ...(isCompact ? typography.priceCompact : typography.price),
+                              color: '#C17A3B',
+                            }}>
+                              ${fmt(item.price)}
+                            </span>
                           )}
                         </div>
-                        {fmt(item.price) != null && (
-                          <span style={{
-                            flexShrink: 0,
-                            ...(isCompact ? typography.priceCompact : typography.price),
-                            color: '#C17A3B',
-                          }}>
-                            ${fmt(item.price)}
-                          </span>
-                        )}
-                      </div>
-                    ))}
+                      );
+
+                      if (isVinosPointer) {
+                        return (
+                          <Link key={ii} href="/carta#vinos" style={{ textDecoration: 'none', cursor: 'pointer' }}
+                            onClick={(e) => { e.preventDefault(); handleTab('VINOS'); }}
+                          >
+                            {row}
+                          </Link>
+                        );
+                      }
+                      return <Fragment key={ii}>{row}</Fragment>;
+                    })}
                   </div>
 
                 </div>

--- a/components/sections/MenuSubtabs.tsx
+++ b/components/sections/MenuSubtabs.tsx
@@ -1,30 +1,25 @@
 'use client';
 
-import { useRef } from 'react';
-import { useScrollFade } from './use-scroll-fade';
-import ScrollFadeEdges from './ScrollFadeEdges';
 import { typography } from '@/lib/typography';
 
 type Props = {
   labels: string[];
   active: string;
   onChange: (label: string) => void;
-  bg: string;
 };
 
-export default function MenuSubtabs({ labels, active, onChange, bg }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
-  const fade = useScrollFade(ref);
-
+// Sin fade de bordes acá a propósito: en pills cortos ("Gin", "Bar") un
+// degradado de 28px tapa buena parte del texto y lo hace ver "apagado" —
+// el propio pill cortado a la mitad ya es la señal de que hay más scroll.
+export default function MenuSubtabs({ labels, active, onChange }: Props) {
   if (labels.length <= 1) return null;
 
   return (
-    <div ref={ref} className="menu-subtabs" role="tablist" onScroll={fade.onScroll} style={{
+    <div className="menu-subtabs" role="tablist" style={{
       position: 'relative',
       display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'center',
       gap: '6px', paddingBottom: '20px', paddingLeft: '16px', paddingRight: '16px',
     }}>
-      <ScrollFadeEdges bg={bg} showLeft={fade.showLeft} showRight={fade.showRight} />
       {labels.map(label => {
         const isActive = active === label;
         return (

--- a/components/sections/MenuTeaser.tsx
+++ b/components/sections/MenuTeaser.tsx
@@ -104,7 +104,7 @@ export default function MenuTeaser() {
               initial={{ opacity: 0, y: 16 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, margin: '-40px' }} transition={{ duration: 0.5, delay: i * 0.08 }}
               style={{ height: '100%' }}
             >
-              <Link href="/carta" style={{
+              <Link href={`/carta#${h.key}`} style={{
                 position: 'relative', display: 'flex', flexDirection: 'column', textDecoration: 'none',
                 background: '#0D0B09', border: '1px solid #2A2520', borderRadius: '16px', overflow: 'hidden',
                 padding: '24px', height: '100%', transition: 'border-color 0.2s',

--- a/lib/menu-fallback.ts
+++ b/lib/menu-fallback.ts
@@ -201,13 +201,13 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
         { name: 'Peroni', desc: 'Italiana', price: 4000 },
       ],
     },
-    // 8. Vinos y Espumantes — el detalle de vinos vive en la tab VINOS
+    // 8. Vinos y Espumantes — el detalle vive 100% en la tab VINOS, este es
+    // solo un puntero para quien está mirando BAR (homologación, ver #237)
     {
       name: 'Vinos y Espumantes',
       subtitle: 'Ver detalle en la carta de Vinos',
       items: [
-        { name: 'Botella Espumante', price: 12000 },
-        { name: 'Copa de Espumante Brut', price: 3500 },
+        { name: 'Vinos y Espumantes', desc: 'Consulta la carta completa en la sección VINOS →', price: '' },
       ],
     },
     // 9. Coctelería Sin Alcohol
@@ -231,100 +231,109 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
         { name: 'Bebidas', price: 2500 },
       ],
     },
-    // 11. Tragos — licores servidos por copa
+    // 11. Destilados — licores servidos por copa, agrupados por tipo (antes
+    // un solo grupo "Tragos" con un desc redundante que solo repetía el tipo).
     {
-      name: 'Tragos',
+      name: 'Pisco',
       items: [
-        { name: 'Chivas Regal', desc: 'Whisky', price: 8000 },
-        { name: 'Horcón Quemado', desc: 'Pisco', price: 7000 },
-        { name: 'Tanqueray', desc: 'Gin', price: 7500 },
-        { name: 'Grants', desc: 'Whisky', price: 6000 },
-        { name: 'Limoncello', desc: 'Bajativo', price: 6000 },
-        { name: 'Bombay', desc: 'Gin', price: 6500 },
-        { name: 'Beefeater', desc: 'Gin', price: 6500 },
-        { name: 'José Cuervo', desc: 'Tequila', price: 5500 },
-        { name: 'Havana', desc: 'Ron', price: 5000 },
-        { name: 'Mistral', desc: 'Pisco', price: 5000 },
-        { name: 'Mistral Manzana', desc: 'Pisco', price: 5000 },
-        { name: 'Alto del Carmen', desc: 'Pisco', price: 5000 },
-        { name: 'Senda', desc: 'Tequila', price: 4000 },
-        { name: 'Amaretto', desc: 'Bajativo', price: 4000 },
-        { name: 'Manzanilla', desc: 'Bajativo', price: 3800 },
-        { name: 'Menta', desc: 'Bajativo', price: 3500 },
-        { name: 'Tequila José Cuervo (Shot)', desc: 'Shot', price: 3000 },
-        { name: 'Jagermeister (Shot)', desc: 'Shot', price: 3000 },
-        { name: 'Fireball (Shot)', desc: 'Shot', price: 3000 },
+        { name: 'Horcón Quemado', price: 7000 },
+        { name: 'Mistral', price: 5000 },
+        { name: 'Mistral Manzana', price: 5000 },
+        { name: 'Alto del Carmen', price: 5000 },
+      ],
+    },
+    {
+      name: 'Ron',
+      items: [
+        { name: 'Havana', price: 5000 },
+      ],
+    },
+    {
+      name: 'Whisky',
+      items: [
+        { name: 'Chivas Regal', price: 8000 },
+        { name: 'Grants', price: 6000 },
+      ],
+    },
+    {
+      name: 'Ginebra',
+      items: [
+        { name: 'Tanqueray', price: 7500 },
+        { name: 'Bombay', price: 6500 },
+        { name: 'Beefeater', price: 6500 },
+      ],
+    },
+    {
+      name: 'Tequila',
+      items: [
+        { name: 'José Cuervo', price: 5500 },
+        { name: 'Senda', price: 4000 },
+      ],
+    },
+    {
+      name: 'Bajativo',
+      items: [
+        { name: 'Limoncello', price: 6000 },
+        { name: 'Amaretto', price: 4000 },
+        { name: 'Manzanilla', price: 3800 },
+        { name: 'Menta', price: 3500 },
+      ],
+    },
+    {
+      name: 'Shots',
+      items: [
+        { name: 'Tequila José Cuervo (Shot)', price: 3000 },
+        { name: 'Jagermeister (Shot)', price: 3000 },
+        { name: 'Fireball (Shot)', price: 3000 },
       ],
     },
   ],
 
   // ── VINOS ─────────────────────────────────────────────────────────────────
-  // Orden de sommelier: blancos → Carménère (cepa insigne, más stock) →
-  // Cabernet Sauvignon → Merlot → Ensamblajes premium → Dulce
+  // Estructura por tier (Reserva / Gran Reserva), no por etiqueta puntual —
+  // el stock real rota por viña/añada, así que el tier es lo único que se
+  // puede garantizar sin re-poblar Notion cada vez que se agota una botella.
+  // Sin tier "Varietal": decisión explícita del dueño (2026-07-18), lo
+  // consideró de imagen muy económica para el posicionamiento del local.
+  // Orden de sommelier: Espumante (aperitivo) → Carménère (cepa insigne) →
+  // Cabernet Sauvignon → Merlot → Blanco (solo si se pide, ver #237)
   VINOS: [
     {
-      name: 'Sauvignon Blanc',
-      subtitle: 'Copa $4.500 · Botella $15.000',
+      name: 'Espumante',
       items: [
-        { name: 'Viu Manent Reserva', desc: 'Valle de Colchagua · cítrico y herbal, ideal aperitivo', price: 15000 },
-      ],
-    },
-    {
-      name: 'Chardonnay',
-      subtitle: 'Copa $4.500 · Botella $15.000',
-      items: [
-        { name: 'Viu Manent Reserva', desc: 'Valle de Colchagua · fresco, mineral, notas de pera', price: 15000 },
-        { name: 'Morandé Pionero Reserva', desc: 'Valle Central · redondo, vainilla suave, persistente', price: 15000 },
+        { name: 'Copa Espumante Brut', price: 3500 },
+        { name: 'Botella Espumante', price: 12000 },
       ],
     },
     {
       name: 'Carménère',
-      subtitle: 'Copa $2.500–$4.500 · Botella $9.000–$20.000',
+      subtitle: 'Cepa insignia de Chile',
       items: [
-        { name: 'Tarapacá Gran Reserva', desc: 'Valle del Maipo · especiado, frutos rojos, terroso', price: 20000 },
-        { name: 'San Pedro Castillo del Maule Gran Reserva', desc: 'Valle del Maule · herbáceo, ciruela negra', price: 20000 },
-        { name: 'Casa Silva Doble D Gran Reserva', desc: 'Valle de Colchagua · elegante, pimienta verde, taninos sedosos', price: 20000 },
-        { name: 'Tarapacá Gran Reserva Etiqueta Negra', desc: 'Valle del Maipo · concentrado, especias, largo final', price: 20000 },
-        { name: 'Santa Helena Gran Reserva', desc: 'Valle Central · redondo, frutos negros, buen cuerpo', price: 20000 },
-        { name: 'Montes Limited Selection', desc: 'Valle de Colchagua · medalla de oro, equilibrado y elegante', price: 15000 },
-        { name: 'Santa Ema Select Terroir', desc: 'Valle del Cachapoal · accesible, frutal y directo', price: 9000 },
+        { name: 'Copa Reserva', desc: 'Pimienta verde y frutos rojos, paso redondo', price: 4500 },
+        { name: 'Botella Reserva', desc: 'Pimienta verde y frutos rojos, paso redondo', price: 15000 },
+        { name: 'Botella Gran Reserva', desc: 'Especiado y terroso, mayor estructura y persistencia', price: 20000 },
       ],
     },
     {
       name: 'Cabernet Sauvignon',
-      subtitle: 'Copa $2.500–$4.500 · Botella $9.000–$20.000',
       items: [
-        { name: 'Santa Ema Select Terroir Reserva Especial', desc: 'Valle del Cachapoal · robusto, cassis y cedro', price: 15000, note: 'Copa disponible' },
-        { name: 'Requingua Toro de Piedra Gran Reserva', desc: 'Valle del Curicó · mineral, ciruela, tabaco', price: 20000 },
-        { name: 'San Pedro Castillo del Maule Tributo Gran Reserva', desc: 'Valle del Maule · potente, especiado, taninos firmes', price: 20000 },
-        { name: 'Tarapacá Gran Reserva Etiqueta Negra', desc: 'Valle del Maipo · intenso, mineral, largo final', price: 20000 },
-        { name: 'Santa Ema Gran Reserva', desc: 'Valle del Cachapoal · estructura clásica, maduro', price: 20000 },
-        { name: 'Casa Silva Doble D Gran Reserva', desc: 'Valle de Colchagua · añadas 2022 · 2023', price: 20000 },
-        { name: 'Santa Rita 120 Reserva', desc: 'Valle del Maipo · accesible, frutos negros, fácil de beber', price: 9000 },
+        { name: 'Copa Reserva', desc: 'Cassis, cedro y tabaco, cuerpo medio-alto', price: 4500 },
+        { name: 'Botella Reserva', desc: 'Cassis, cedro y tabaco, cuerpo medio-alto', price: 15000 },
+        { name: 'Botella Gran Reserva', desc: 'Concentrado, mineral, final largo', price: 20000 },
       ],
     },
     {
       name: 'Merlot',
-      subtitle: 'Copa $4.500 · Botella $15.000',
+      subtitle: 'Sin Gran Reserva por ahora — sin stock de ese tier',
       items: [
-        { name: 'Santa Ema Select Terroir Reserva Especial', desc: 'Valle del Cachapoal · suave, ciruela y chocolate', price: 15000 },
-        { name: 'Santa Catalina El Arpa Blue Reserva Fría', desc: 'Valle Central · fresco, frutos rojos, especias', price: 15000 },
-        { name: 'Santa Rita Medalla Real Reserva', desc: 'Valle del Maipo · aterciopelado, baya oscura', price: 15000 },
+        { name: 'Copa Reserva', desc: 'Ciruela madura y chocolate, el tinto más amigable de la carta', price: 4500 },
+        { name: 'Botella Reserva', desc: 'Ciruela madura y chocolate, el tinto más amigable de la carta', price: 15000 },
       ],
     },
     {
-      name: 'Ensamblajes',
-      subtitle: 'Botella $20.000',
+      name: 'Blanco',
       items: [
-        { name: 'Tarapacá Gran Reserva Etiqueta Azul', desc: 'Cabernet · Carménère · Syrah · Valle del Maipo', price: 20000 },
-        { name: 'San Pedro Sideral', desc: 'Blend de autor · Valle del Cachapoal · reconocido mundialmente', price: 20000 },
-      ],
-    },
-    {
-      name: 'Dulce',
-      subtitle: 'Botella $9.000',
-      items: [
-        { name: '7 Colores Cortejo Moscato', desc: 'Valle Central · notas de durazno, flores blancas y miel', price: 9000 },
+        { name: 'Botella Blanco', desc: 'Fresco y mineral, ideal como aperitivo o con antipasti de mar', price: 15000, note: 'Sauvignon Blanc o Chardonnay, según disponibilidad' },
       ],
     },
   ],

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -101,10 +101,15 @@ function parseMenuPages(
       result[tab] = []
       continue
     }
-    result[tab] = Array.from(groups.entries()).map(([name, items]) => ({
-      name: name || undefined,
-      items,
-    }))
+    // Un grupo puede quedar vacío si TODOS sus ítems se filtraron por el
+    // filtro de días (ej. Happy Hour un sábado) — sin esto, el banner del
+    // grupo (o su subtab) se renderiza igual con cero ítems debajo.
+    result[tab] = Array.from(groups.entries())
+      .filter(([, items]) => items.length > 0)
+      .map(([name, items]) => ({
+        name: name || undefined,
+        items,
+      }))
   }
 
   return result

--- a/tests/e2e/carta.spec.ts
+++ b/tests/e2e/carta.spec.ts
@@ -4,8 +4,8 @@ test.describe('Carta digital (/carta)', () => {
   test('home de la carta muestra el selector de secciones, sin productos', async ({ page }) => {
     await page.goto('/carta');
     await expect(page.getByRole('heading', { name: /para todos los gustos/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /ANTIPASTI/ }).first()).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'ANTIPASTI' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /ENTRADAS/ }).first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'ENTRADAS' })).not.toBeVisible();
   });
 
   test('elegir una sección muestra sus productos y el ícono home vuelve al selector', async ({ page }) => {
@@ -35,42 +35,44 @@ test.describe('Carta digital (/carta)', () => {
 
 test.describe('Subtabs de BAR y VINOS (/carta)', () => {
   // VINOS siempre usa FALLBACK_MENU (page.tsx fuerza esto aunque Notion esté configurado),
-  // así que sus 3 subtabs (Blancos, Tintos, Ensamblajes y Dulce) son deterministas.
-  test('VINOS: click en "Tintos" muestra solo los tintos y oculta los blancos', async ({ page }) => {
+  // así que sus 5 subtabs (Espumante, Carménère, Cabernet Sauvignon, Merlot, Blanco) —
+  // uno por Subcategoría real, sin agrupar — son deterministas (ver #237).
+  test('VINOS: click en "Carménère" muestra solo ese varietal y oculta los demás', async ({ page }) => {
     await page.goto('/carta#vinos');
     await expect(page.getByRole('heading', { name: 'VINOS' })).toBeVisible();
 
-    await expect(page.getByRole('tab', { name: 'Sauvignon Blanc' })).toHaveCount(0); // no es subtab, es grupo
-    await page.getByRole('tab', { name: 'Tintos' }).click();
+    await page.getByRole('tab', { name: 'Carménère' }).click();
 
     await expect(page.getByRole('heading', { name: 'Carménère' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Cabernet Sauvignon' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Merlot' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).not.toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Chardonnay' })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Cabernet Sauvignon' })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Merlot' })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Espumante' })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Blanco' })).not.toBeVisible();
   });
 
   test('VINOS: subtab "Todos" muestra todos los grupos', async ({ page }) => {
     await page.goto('/carta#vinos');
-    await page.getByRole('tab', { name: 'Tintos' }).click();
-    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).not.toBeVisible();
+    await page.getByRole('tab', { name: 'Carménère' }).click();
+    await expect(page.getByRole('heading', { name: 'Espumante' })).not.toBeVisible();
 
     await page.getByRole('tab', { name: 'Todos' }).click();
-    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Espumante' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Carménère' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Dulce' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Cabernet Sauvignon' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Merlot' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Blanco' })).toBeVisible();
   });
 
   test('cambiar de tab principal resetea el subtab activo a "Todos"', async ({ page }) => {
     await page.goto('/carta#vinos');
-    await page.getByRole('tab', { name: 'Tintos' }).click();
-    await expect(page.getByRole('tab', { name: 'Tintos' })).toHaveAttribute('aria-selected', 'true');
+    await page.getByRole('tab', { name: 'Carménère' }).click();
+    await expect(page.getByRole('tab', { name: 'Carménère' })).toHaveAttribute('aria-selected', 'true');
 
     await page.getByRole('button', { name: /^BAR$/ }).click();
     await page.getByRole('button', { name: /^VINOS$/ }).click();
 
     await expect(page.getByRole('tab', { name: 'Todos' })).toHaveAttribute('aria-selected', 'true');
-    await expect(page.getByRole('heading', { name: 'Sauvignon Blanc' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Espumante' })).toBeVisible();
   });
 
   // BAR puede venir de Notion (contenido variable) — se valida el comportamiento de

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -56,7 +56,7 @@ test.describe('Secciones principales', () => {
     for (const label of ['Pizzas', 'Fondos', 'Bar', 'Postres']) {
       const heading = page.getByRole('heading', { name: label, exact: true });
       await expect(heading).toBeVisible();
-      const card = page.locator('#menu a[href="/carta"]').filter({ has: heading });
+      const card = page.locator('#menu a[href^="/carta#"]').filter({ has: heading });
       await expect(card.locator('img')).toBeVisible();
     }
   });


### PR DESCRIPTION
Closes #244

## Resumen
- BAR "Tragos" reestructurado en 7 subsecciones reales (Pisco, Ron, Whisky, Ginebra, Tequila, Bajativo, Shots) — antes un grupo plano con desc redundante.
- VINOS: cada varietal (Carménère, Cabernet Sauvignon, Merlot, Espumante, Blanco) ahora es su propio subtab.
- Puntero "Vinos y Espumantes" en BAR navega de verdad a VINOS (antes solo texto).
- Rename decorativo ANTIPASTI → ENTRADAS.
- **Bug real corregido**: un grupo cuyos ítems quedan 100% excluidos por el filtro de días (L/M/W/J/V/S/D) sobrevivía vacío con su banner visible — encontrado al configurar Happy Hour para ocultarse fines de semana.
- Las 4 cards de "Para todos los gustos" en el landing ahora redirigen a su sección específica de /carta.
- Se quitó el degradado de sombra en los bordes de los subtabs (tapaba texto en pills cortos como "Gin").

Contenido de Notion (VINOS/BAR) ya publicado por el dev antes de este PR — este PR es 100% código.

## Test plan
- [x] `pnpm build`/typecheck limpio
- [x] Gate completo de Playwright: 41/41 verde (corrido 2 veces en worktree limpio)
- [x] Verificado manualmente en navegador: subtabs de BAR/VINOS, puntero de vinos, Happy Hour oculto sábado/domingo (vía Draft Mode + datos reales de Notion), cards del landing, sombra de subtabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)