### PR TITLE
fix(carta): Happy Hour no se ocultaba — código pendiente tras merge de #245

### DIFF
--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -341,8 +341,12 @@ export default function Menu({ menu }: Props) {
               const isHappyHour = group.name === 'Happy Hour';
               const isKids = group.name === 'Para Niños';
               const isSemanaleChef = active === 'SEMANAL' && group.name === 'Menú del Chef';
-              const noDesc = group.items.every(i => !i.desc);
-              const isCompact = noDesc && group.items.length > 2;
+              // Compacto = sin desc, punto. El umbral de "> 2 ítems" quedó
+              // sacando grupos chicos (ej. Ron con 1 ítem) del modo compacto
+              // aunque estuvieran al lado de otros grupos sin desc que sí
+              // calificaban — mismo tab, tamaños de letra distintos sin razón
+              // de contenido real.
+              const isCompact = group.items.every(i => !i.desc);
               // Puntero "ver detalle en Vinos" — el único ítem de este grupo en BAR
               // debe navegar de verdad a la tab VINOS, no quedar como texto suelto.
               const isVinosPointer = active === 'BAR' && group.name === 'Vinos y Espumantes';

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -35,23 +35,29 @@ type NotionMenuPage = {
     Nota: { rich_text: NotionText[] }
     Badge: { rich_text: NotionText[] }
     Orden: { number: number | null }
-    // Días activos — L=Lunes M=Martes W=Miércoles J=Jueves V=Viernes S=Sábado D=Domingo
-    // Todos en false (default) = mostrar siempre. Al menos uno en true = mostrar sólo ese(os) día(s).
-    L?: { checkbox: boolean }
-    M?: { checkbox: boolean }
-    W?: { checkbox: boolean }
-    J?: { checkbox: boolean }
-    V?: { checkbox: boolean }
-    S?: { checkbox: boolean }
-    D?: { checkbox: boolean }
+    // Días en que el ítem aparece — convención: se marcan explícitamente
+    // TODOS los días en que corresponde mostrarlo (incluye "siempre" = los
+    // 7 marcados), nunca se confía en dejarlos en blanco para eso. Un ítem
+    // recién creado sin marcar ningún día simplemente se muestra siempre
+    // (red de seguridad — no rompe contenido nuevo sin configurar), pero la
+    // práctica esperada es marcar explícito.
+    Lunes?: { checkbox: boolean }
+    Martes?: { checkbox: boolean }
+    Miércoles?: { checkbox: boolean }
+    Jueves?: { checkbox: boolean }
+    Viernes?: { checkbox: boolean }
+    Sábado?: { checkbox: boolean }
+    Domingo?: { checkbox: boolean }
   }
 }
 
 const VALID_TABS = new Set<string>(['ENTRADAS', 'PIZZAS', 'FONDOS', 'POSTRES', 'BAR', 'VINOS', 'SEMANAL'])
 
+const DAY_KEYS = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'] as const
+
 // El servidor de Vercel corre en UTC — Chile es UTC-3/-4, así que el día de
 // la semana hay que calcularlo en su propia timezone, no con Date.getDay().
-const WEEKDAY_TO_KEY = { Sun: 'D', Mon: 'L', Tue: 'M', Wed: 'W', Thu: 'J', Fri: 'V', Sat: 'S' } as const
+const WEEKDAY_TO_KEY = { Sun: 'Domingo', Mon: 'Lunes', Tue: 'Martes', Wed: 'Miércoles', Thu: 'Jueves', Fri: 'Viernes', Sat: 'Sábado' } as const
 const CHILE_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', { timeZone: 'America/Santiago', weekday: 'short' })
 
 function parseMenuPages(
@@ -74,7 +80,7 @@ function parseMenuPages(
     if (!groups.has(subcat)) groups.set(subcat, [])
 
     // Filtro de días
-    const anyDaySet = (['L', 'M', 'W', 'J', 'V', 'S', 'D'] as const).some(k => p[k]?.checkbox === true)
+    const anyDaySet = DAY_KEYS.some(k => p[k]?.checkbox === true)
     if (anyDaySet && !p[todayKey]?.checkbox) continue
 
     const nameEs = p.Nombre?.title?.[0]?.plain_text ?? ''

--- a/scripts/populate-vinos-semanal.mjs
+++ b/scripts/populate-vinos-semanal.mjs
@@ -43,19 +43,19 @@ const H = {
 const sleep = ms => new Promise(r => setTimeout(r, ms))
 
 // ── 1. Agregar propiedades de días al schema ────────────────────────────────────
-console.log('\n→ Actualizando schema: añadiendo propiedades L/M/W/J/V/S/D ...')
+console.log('\n→ Actualizando schema: añadiendo propiedades Lunes..Domingo ...')
 const schemaPatch = await fetch(`https://api.notion.com/v1/databases/${DB_ID}`, {
   method: 'PATCH',
   headers: H,
   body: JSON.stringify({
     properties: {
-      L: { checkbox: {} },
-      M: { checkbox: {} },
-      W: { checkbox: {} },
-      J: { checkbox: {} },
-      V: { checkbox: {} },
-      S: { checkbox: {} },
-      D: { checkbox: {} },
+      Lunes: { checkbox: {} },
+      Martes: { checkbox: {} },
+      Miércoles: { checkbox: {} },
+      Jueves: { checkbox: {} },
+      Viernes: { checkbox: {} },
+      Sábado: { checkbox: {} },
+      Domingo: { checkbox: {} },
     },
   }),
 })
@@ -86,14 +86,15 @@ async function createItem(cat, subcat, item) {
     Categoría: { select: { name: cat } },
     Activo: { checkbox: true },
     Orden: { number: item.ord ?? 0 },
-    // Días — false por defecto = mostrar siempre
-    L: { checkbox: item.dias?.includes('L') ?? false },
-    M: { checkbox: item.dias?.includes('M') ?? false },
-    W: { checkbox: item.dias?.includes('W') ?? false },
-    J: { checkbox: item.dias?.includes('J') ?? false },
-    V: { checkbox: item.dias?.includes('V') ?? false },
-    S: { checkbox: item.dias?.includes('S') ?? false },
-    D: { checkbox: item.dias?.includes('D') ?? false },
+    // Días — sin `item.dias` se marcan los 7 (siempre visible, explícito).
+    // Con `item.dias` (ej. ['Miércoles','Jueves','Viernes']) solo esos quedan marcados.
+    Lunes: { checkbox: item.dias?.includes('Lunes') ?? true },
+    Martes: { checkbox: item.dias?.includes('Martes') ?? true },
+    Miércoles: { checkbox: item.dias?.includes('Miércoles') ?? true },
+    Jueves: { checkbox: item.dias?.includes('Jueves') ?? true },
+    Viernes: { checkbox: item.dias?.includes('Viernes') ?? true },
+    Sábado: { checkbox: item.dias?.includes('Sábado') ?? true },
+    Domingo: { checkbox: item.dias?.includes('Domingo') ?? true },
   }
   if (item.desc) props['Descripción'] = { rich_text: [{ text: { content: item.desc } }] }
   if (item.price != null && item.price !== '') props['Precio'] = { number: item.price }
@@ -162,8 +163,8 @@ const VINOS_GROUPS = [
 /**
  * SEMANAL — menú del chef. Cambia semanalmente.
  * Subcategorías: "Menú del Chef" y "Elige tu Opción"
- * Para restringir días: agregar `dias: ['L','M','W','J','V']` en el ítem.
- * Sin `dias` (o array vacío) = mostrar siempre.
+ * Para restringir días: agregar `dias: ['Lunes','Martes','Miércoles','Jueves','Viernes']` en el ítem.
+ * Sin `dias` = se marcan los 7 (mostrar siempre, explícito).
  *
  * Este menú de ejemplo viene del Canva (2026-06-30).
  * En Notion puedes desactivar un ítem (Activo=false) y crear el nuevo
@@ -174,7 +175,7 @@ const SEMANAL_GROUPS = [
     {
       name: 'Entrada',
       desc: 'Reineta fresca del día con el toque justo de limón y especias, presentada sobre una delicada crema de palta artesanal. Una entrada ligera y refrescante.',
-      // dias: ['L','M','W','J','V']  ← descomentar para mostrar solo lunes a viernes
+      // dias: ['Lunes','Martes','Miércoles','Jueves','Viernes']  ← descomentar para mostrar solo lunes a viernes
       ord: 1,
     },
     {


### PR DESCRIPTION
## Por qué existe este PR
Después de mergear #245, seguía apareciendo Happy Hour en dev.dimoe.cl un sábado. Causa: dos cambios de código quedaron hechos en el worktree pero nunca comiteados antes del merge anterior:

1. **Rename de columnas de días en Notion** (L/M/W/J/V/S/D → Lunes...Domingo, para que sean explícitas al editar) — el schema de Notion ya se renombró, pero `lib/menu.ts` seguía buscando las propiedades viejas, que ya no existen. Resultado: `anyDaySet` siempre `false` para todo, así que Happy Hour (y cualquier restricción de día) se ignoraba por completo.
2. **Tipografía compacta consistente**: el modo compacto dependía de `noDesc && length > 2`, dejando grupos chicos sin desc (ej. Ron con 1 ítem) fuera del modo compacto aunque estuvieran al lado de otros que sí calificaban — mismo tab, tamaños de letra distintos sin razón real.

## Verificación
- Typecheck limpio.
- Verificado con Draft Mode + datos reales de Notion (hoy es sábado): Happy Hour ya no aparece.
- Gate completo: 41/41 verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)