### PR TITLE
feat(carta): links de Carta Delivery/Retiro en el home de /carta

### DIFF
--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from 'next';
 import { draftMode } from 'next/headers';
-import { getTranslations } from 'next-intl/server';
-import { Link } from '@/i18n/navigation';
 import Menu from '@/components/sections/Menu';
 import CartaFooter from '@/components/sections/CartaFooter';
 import { getMenu, getMenuPreview } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
-import { typography } from '@/lib/typography';
 
 export const maxDuration = 30;
 
@@ -54,14 +51,6 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
           </a>
         </div>
       )}
-      {/* Back link */}
-      <div style={{ maxWidth: '860px', margin: '0 auto', padding: '24px clamp(16px, 4vw, 24px) 0' }}>
-        <Link href="/" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', ...typography.bodySm, color: 'rgba(242,237,228,0.45)', textDecoration: 'none', transition: 'color 0.2s' }}>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ display: 'block', flexShrink: 0 }}><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
-          <span style={{ display: 'inline-block', lineHeight: '14px' }}>{isEn ? 'Back to home' : 'Volver al inicio'}</span>
-        </Link>
-      </div>
-
       <Menu menu={menuData} />
       <CartaFooter />
     </main>

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -176,6 +176,31 @@ export default function Menu({ menu }: Props) {
   };
 
   return (
+    <>
+    {/* Back link + accesos de pedido — estos últimos solo en el home de /carta */}
+    <div style={{
+      maxWidth: '860px', margin: '0 auto', padding: '24px clamp(16px, 4vw, 24px) 0',
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '12px',
+    }}>
+      <Link href="/" style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', ...typography.bodySm, color: 'rgba(242,237,228,0.45)', textDecoration: 'none', transition: 'color 0.2s' }}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ display: 'block', flexShrink: 0 }}><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        <span style={{ display: 'inline-block', lineHeight: '14px' }}>{locale === 'en' ? 'Back to home' : 'Volver al inicio'}</span>
+      </Link>
+      {!active && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px', flexWrap: 'wrap' }}>
+          <a href="https://piderural.cl/stores/dimoe/" target="_blank" rel="noopener noreferrer"
+            style={{ ...typography.bodySm, lineHeight: '14px', color: '#C17A3B', textDecoration: 'none', transition: 'color 0.2s' }}
+          >
+            Carta Delivery
+          </a>
+          <a href="https://menu.fu.do/dimoe" target="_blank" rel="noopener noreferrer"
+            style={{ ...typography.bodySm, lineHeight: '14px', color: '#C17A3B', textDecoration: 'none', transition: 'color 0.2s' }}
+          >
+            Carta Retiro
+          </a>
+        </div>
+      )}
+    </div>
     <section
       id="menu"
       ref={sectionRef}
@@ -519,5 +544,6 @@ export default function Menu({ menu }: Props) {
       </div>
       </>)}
     </section>
+    </>
   );
 }


### PR DESCRIPTION
## Resumen
Dos links nuevos en la fila de "Volver al inicio" del home de `/carta`, solo visibles ahí (no en tabs individuales):
- **Carta Delivery** → https://piderural.cl/stores/dimoe/
- **Carta Retiro** → https://menu.fu.do/dimoe

Ambos abren en pestaña nueva (`target="_blank" rel="noopener noreferrer"`).

## Por qué se movió código de page.tsx a Menu.tsx
La visibilidad condicional (solo home, no tabs) depende de qué tab está activo — ese estado es client-side y vive dentro de `Menu.tsx`, no en `page.tsx` (Server Component). Mover el bloque de "Volver al inicio" a `Menu.tsx` evita duplicar/desincronizar ese estado con un componente aparte.

## Verificación
- Typecheck limpio.
- Verificado en navegador (desktop y mobile 390px): los links aparecen en el home, desaparecen en cualquier tab, sin ensanchar el contenedor de 860px, todo alineado en una sola fila.
- Gate completo: 41/41 verde (corrido 2 veces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)