### PR TITLE
feat(carta): orden en 2 niveles + badges Vegetariano/Picante

### DIFF
--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -25,7 +25,10 @@ async function fetchNotionMenuRaw(): Promise<unknown[]> {
       },
       body: JSON.stringify({
         filter: { property: 'Activo', checkbox: { equals: true } },
-        sorts: [{ property: 'Orden', direction: 'ascending' }],
+        sorts: [
+          { property: 'Orden Sección', direction: 'ascending' },
+          { property: 'Orden', direction: 'ascending' },
+        ],
         page_size: 100,
         ...(cursor ? { start_cursor: cursor } : {}),
       }),

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -126,6 +126,15 @@ const IconVegan = () => (
   </svg>
 );
 
+// Espiga de trigo tachada — símbolo estándar de "libre de gluten"
+const IconGlutenFree = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <path d="M12 21V4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+    <path d="M12 6l-3-2M12 6l3-2M12 10l-3-2M12 10l3-2M12 14l-3-2M12 14l3-2" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M4 4l16 16" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+  </svg>
+);
+
 type Props = { menu?: Record<MenuTab, MenuGroup[]> }
 
 export default function Menu({ menu }: Props) {
@@ -520,6 +529,15 @@ export default function Menu({ menu }: Props) {
                                   border: '1px solid rgba(78,155,122,0.5)', color: '#4E9B7A',
                                 }}>
                                   <IconVegan />
+                                </span>
+                              )}
+                              {item.libreDeGluten && (
+                                <span title="Libre de Gluten: Apto para intolerantes pero no para alérgicos (no es libre de trazas)" style={{
+                                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                                  width: '20px', height: '20px', borderRadius: '50%', flexShrink: 0,
+                                  border: '1px solid rgba(196,148,59,0.5)', color: '#C4943B',
+                                }}>
+                                  <IconGlutenFree />
                                 </span>
                               )}
                             </div>

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -119,6 +119,13 @@ const IconChili = () => (
   </svg>
 );
 
+const IconVegan = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <path d="M5 13c0 6 4.5 8 7 8s7-2 7-8c-3 0-5 1-7 3-2-2-4-3-7-3z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round"/>
+    <path d="M12 21V9c0-3 2-5 6-5 0 4-1.5 6-4 6.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
 type Props = { menu?: Record<MenuTab, MenuGroup[]> }
 
 export default function Menu({ menu }: Props) {
@@ -504,6 +511,15 @@ export default function Menu({ menu }: Props) {
                                   border: '1px solid rgba(193,80,59,0.5)', color: '#C1503B',
                                 }}>
                                   <IconChili />
+                                </span>
+                              )}
+                              {item.veganizable && (
+                                <span title="Veganizable: 100% libre de origen animal" style={{
+                                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                                  width: '20px', height: '20px', borderRadius: '50%', flexShrink: 0,
+                                  border: '1px solid rgba(78,155,122,0.5)', color: '#4E9B7A',
+                                }}>
+                                  <IconVegan />
                                 </span>
                               )}
                             </div>

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -104,6 +104,21 @@ function fmt(p: number | string | undefined | null): string | null {
   return p.toLocaleString('es-CL');
 }
 
+// Íconos de flags dietarios — trazo fino, mismo estilo que MenuTeaser
+const IconLeaf = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <path d="M20 4C10 4 4 10 4 18v2h2c8 0 14-6 14-16V4z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round"/>
+    <path d="M6 18C10 14 14 10 19 5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+  </svg>
+);
+
+const IconChili = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <path d="M8 8c-2 2-3 5-2 8 1 3 4 4 7 3 4-1.5 6-5 5-9-1-3.5-4-5-7-4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M9 7c-1-2-1-4 1-5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+  </svg>
+);
+
 type Props = { menu?: Record<MenuTab, MenuGroup[]> }
 
 export default function Menu({ menu }: Props) {
@@ -471,6 +486,24 @@ export default function Menu({ menu }: Props) {
                                   borderRadius: '100px', padding: '2px 8px', whiteSpace: 'nowrap',
                                 }}>
                                   {item.badge}
+                                </span>
+                              )}
+                              {item.vegetariano && (
+                                <span title="Vegetariano" style={{
+                                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                                  width: '20px', height: '20px', borderRadius: '50%', flexShrink: 0,
+                                  border: '1px solid rgba(127,166,90,0.5)', color: '#7FA65A',
+                                }}>
+                                  <IconLeaf />
+                                </span>
+                              )}
+                              {item.picante && (
+                                <span title="Picante" style={{
+                                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                                  width: '20px', height: '20px', borderRadius: '50%', flexShrink: 0,
+                                  border: '1px solid rgba(193,80,59,0.5)', color: '#C1503B',
+                                }}>
+                                  <IconChili />
                                 </span>
                               )}
                             </div>

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -15,6 +15,7 @@ export type MenuItem = {
   vegetariano?: boolean
   picante?: boolean
   veganizable?: boolean
+  libreDeGluten?: boolean
 }
 
 export type MenuGroup = {
@@ -40,6 +41,7 @@ type NotionMenuPage = {
     Vegetariano?: { checkbox: boolean }
     Picante?: { checkbox: boolean }
     Veganizable?: { checkbox: boolean }
+    'Libre de Gluten'?: { checkbox: boolean }
     // Orden de dos niveles: 'Orden Sección' ordena los grupos entre sí
     // (Happy Hour, Cervezas, ...) y 'Orden' ordena los productos dentro de
     // su propia sección — así reordenar un producto nunca requiere tocar
@@ -109,6 +111,7 @@ function parseMenuPages(
       vegetariano: p.Vegetariano?.checkbox || undefined,
       picante: p.Picante?.checkbox || undefined,
       veganizable: p.Veganizable?.checkbox || undefined,
+      libreDeGluten: p['Libre de Gluten']?.checkbox || undefined,
     }
 
     groups.get(subcat)!.push(item)

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -12,6 +12,8 @@ export type MenuItem = {
   price: number | string
   badge?: string
   note?: string
+  vegetariano?: boolean
+  picante?: boolean
 }
 
 export type MenuGroup = {
@@ -34,6 +36,13 @@ type NotionMenuPage = {
     Tag: { select: { name: string } | null }
     Nota: { rich_text: NotionText[] }
     Badge: { rich_text: NotionText[] }
+    Vegetariano?: { checkbox: boolean }
+    Picante?: { checkbox: boolean }
+    // Orden de dos niveles: 'Orden Sección' ordena los grupos entre sí
+    // (Happy Hour, Cervezas, ...) y 'Orden' ordena los productos dentro de
+    // su propia sección — así reordenar un producto nunca requiere tocar
+    // el número de otra sección ni usar decimales para "hacer espacio".
+    'Orden Sección': { number: number | null }
     Orden: { number: number | null }
     // Días en que el ítem aparece — convención: se marcan explícitamente
     // TODOS los días en que corresponde mostrarlo (incluye "siempre" = los
@@ -95,6 +104,8 @@ function parseMenuPages(
       price: p.Precio?.number ?? '',
       badge: badge || undefined,
       note: p.Nota?.rich_text?.[0]?.plain_text || undefined,
+      vegetariano: p.Vegetariano?.checkbox || undefined,
+      picante: p.Picante?.checkbox || undefined,
     }
 
     groups.get(subcat)!.push(item)
@@ -173,7 +184,10 @@ export async function getMenuPreview(
         },
         body: JSON.stringify({
           filter: { property: 'Activo', checkbox: { equals: true } },
-          sorts: [{ property: 'Orden', direction: 'ascending' }],
+          sorts: [
+            { property: 'Orden Sección', direction: 'ascending' },
+            { property: 'Orden', direction: 'ascending' },
+          ],
           page_size: 100,
           ...(cursor ? { start_cursor: cursor } : {}),
         }),

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -14,6 +14,7 @@ export type MenuItem = {
   note?: string
   vegetariano?: boolean
   picante?: boolean
+  veganizable?: boolean
 }
 
 export type MenuGroup = {
@@ -38,6 +39,7 @@ type NotionMenuPage = {
     Badge: { rich_text: NotionText[] }
     Vegetariano?: { checkbox: boolean }
     Picante?: { checkbox: boolean }
+    Veganizable?: { checkbox: boolean }
     // Orden de dos niveles: 'Orden Sección' ordena los grupos entre sí
     // (Happy Hour, Cervezas, ...) y 'Orden' ordena los productos dentro de
     // su propia sección — así reordenar un producto nunca requiere tocar
@@ -106,6 +108,7 @@ function parseMenuPages(
       note: p.Nota?.rich_text?.[0]?.plain_text || undefined,
       vegetariano: p.Vegetariano?.checkbox || undefined,
       picante: p.Picante?.checkbox || undefined,
+      veganizable: p.Veganizable?.checkbox || undefined,
     }
 
     groups.get(subcat)!.push(item)


### PR DESCRIPTION
## 1. Orden en 2 niveles
Antes un solo campo `Orden` ordenaba grupos entre sí Y productos dentro de un grupo — reordenar un producto sin desordenar otra sección obligaba a usar decimales (`8.05` para meterlo entre el `8` y el `8.1`).

Ahora:
- **`Orden Sección`** (nuevo, en Notion): ordena las secciones entre sí (Happy Hour, Cervezas, etc.). Mismo valor para todos los ítems de una misma Subcategoría.
- **`Orden`**: solo ordena productos dentro de su propia sección — enteros simples (1, 2, 3...), sin pensar en el resto de la carta.

Los 146 ítems activos se migraron preservando exactamente el orden visual actual (verificado). `lib/menu.ts` y `app/api/publish/route.ts` ordenan por `['Orden Sección', 'Orden']` en cascada.

## 2. Badges de flags dietarios: Vegetariano, Picante, Veganizable, Libre de Gluten
Cuatro checkboxes en Notion (`Vegetariano`, `Picante`, `Veganizable`, `Libre de Gluten`). Cuando están marcados, aparece un badge circular (ícono de hoja / ají / vegan / espiga tachada, mismo estilo de trazo fino que los íconos de MenuTeaser) junto al nombre del ítem, con tooltip nativo.

**No se marcó ningún producto real** en ninguno de los 4 — la infraestructura queda lista, pero cuáles platos son vegetarianos/picantes/veganizables/libres de gluten es una decisión de contenido que le toca al dueño del negocio.

⚠ Las columnas `Veganizable` y `Libre de Gluten` todavía no existen en la base de Notion — hay que crearlas ahí (checkbox) antes de poder marcar productos reales o probar con datos reales en Draft Mode.

Closes #249
Closes #250
Closes #251
Closes #252

## Verificación
- Typecheck limpio (`tsc --noEmit`) en cada commit.
- `pnpm build` verde.
- 41/41 Playwright verde, sin regresiones.
- Verificado con Draft Mode + Notion real: orden de subtabs de BAR sin cambios, badges de Vegetariano/Picante probados con datos reales vía navegador headless (Playwright) — el render funciona correctamente end-to-end.
- Gate completo: 41/41 verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)