### PR TITLE
fix(carta): subtítulo hardcoded de Menú de la Semana (fix #253)

### DIFF
--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -421,7 +421,7 @@ export default function Menu({ menu }: Props) {
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '4px' }}>
                         <span style={{ ...typography.titleMd, color: 'rgba(220,80,80,0.9)' }}>Menú de la Semana</span>
                         <span style={{ ...typography.caption, color: 'rgba(220,80,80,0.55)' }}>
-                          {group.subtitle ?? 'Actualización semanal · consultar disponibilidad'}
+                          {group.subtitle ?? 'Disponible hasta las 16:00 hrs'}
                         </span>
                       </div>
                     </div>

--- a/lib/menu-fallback.ts
+++ b/lib/menu-fallback.ts
@@ -342,7 +342,7 @@ export const FALLBACK_MENU: Record<MenuTab, MenuGroup[]> = {
   SEMANAL: [
     {
       name: 'Menú del Chef',
-      subtitle: 'Actualización semanal · consultar disponibilidad',
+      subtitle: 'Disponible hasta las 16:00 hrs',
       items: [
         { name: 'Entrada', desc: 'Reineta fresca del día con el toque justo de limón y especias, presentada sobre una delicada crema de palta artesanal. Una entrada ligera y refrescante.', price: '' },
         { name: 'Fondo', desc: 'Jugoso filete de salmón en su propia emulsión, servido sobre un artesanal puré de papas y zapallo. Terminado con una fresca salsa de alcaparras y cilantro.', price: '' },


### PR DESCRIPTION
Closes #253

## Tasks incluidas
- Closes #254 — fix: cambiar subtítulo hardcoded de "Actualización semanal · consultar disponibilidad" a "Disponible hasta las 16:00 hrs"

## Resumen
- Corrige el copy hardcoded del subtítulo de "Menú de la Semana" en `/carta` en los 2 lugares donde aparecía: `lib/menu-fallback.ts` y el valor por defecto en `components/sections/Menu.tsx`.

## Test plan
- [x] `pnpm build` verde
- [x] 41/41 Playwright verde, sin regresiones
- [ ] Verificar visualmente en `/carta#semanal` tras el merge que el subtítulo muestre "Disponible hasta las 16:00 hrs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)