### PR TITLE
fix(carta): banner de Happy Hour ahora envuelve los productos (fix #259)

### DIFF
--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -427,20 +427,20 @@ export default function Menu({ menu }: Props) {
                     </div>
                   )}
 
-                  {/* Happy Hour — banner ámbar, tratamiento explícito para diferenciarlo del resto de la carta */}
+                  {/* Happy Hour — caja ámbar que envuelve header + TODOS los ítems, para diferenciarlo del resto de la carta */}
+                  <div style={isHappyHour ? {
+                    background: 'linear-gradient(135deg, rgba(193,122,59,0.3) 0%, rgba(193,122,59,0.16) 100%)',
+                    border: '2px solid rgba(193,122,59,0.6)',
+                    borderLeft: '5px solid #C17A3B',
+                    borderRadius: '6px 10px 10px 6px', padding: '14px 18px 6px 16px', marginBottom: '16px',
+                  } : undefined}>
+
                   {isHappyHour && (
-                    <div style={{
-                      background: 'linear-gradient(135deg, rgba(193,122,59,0.3) 0%, rgba(193,122,59,0.16) 100%)',
-                      border: '2px solid rgba(193,122,59,0.6)',
-                      borderLeft: '5px solid #C17A3B',
-                      borderRadius: '6px 10px 10px 6px', padding: '13px 18px 10px 15px', marginBottom: '16px',
-                    }}>
-                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '4px' }}>
-                        <span style={{ ...typography.titleMd, color: '#C17A3B' }}>Happy Hour</span>
-                        <span style={{ ...typography.caption, color: 'rgba(193,122,59,0.85)' }}>
-                          {group.subtitle ?? 'Miércoles a Viernes · 17:00 – 20:00'}
-                        </span>
-                      </div>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '4px', marginBottom: '10px' }}>
+                      <span style={{ ...typography.titleMd, color: '#C17A3B' }}>Happy Hour</span>
+                      <span style={{ ...typography.caption, color: 'rgba(193,122,59,0.85)' }}>
+                        {group.subtitle ?? 'Miércoles a Viernes · 17:00 – 20:00'}
+                      </span>
                     </div>
                   )}
 
@@ -576,6 +576,8 @@ export default function Menu({ menu }: Props) {
                       }
                       return <Fragment key={ii}>{row}</Fragment>;
                     })}
+                  </div>
+
                   </div>
 
                 </div>


### PR DESCRIPTION
Closes #259

## Tasks incluidas
- Closes #260 — fix: envolver header + items de Happy Hour en un solo contenedor

## Resumen
- Corrige una regresión de PR #258: la caja ámbar del banner "Happy Hour" solo envolvía el título, dejando los productos con el estilo plano de siempre. Ahora la caja envuelve header + todos los productos de esa sección.

## Test plan
- [x] `pnpm build` verde
- [x] Verificado con screenshot real (Playwright, mobile 390px) — todos los productos quedan dentro de la caja
- [x] Playwright gate: 32/41 en corrida con contención, confirmado 100% verde en re-corridas aisladas (los 9 fallos fueron flakiness de arranque en frío, no relacionados a este cambio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)