### PR TITLE
feat(api): protección contra abuso en formularios públicos y hardening de secretos (feature #235)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ NOTION_DB_MENU=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # On-demand revalidation (/api/revalidate?secret=...&tag=menu)
 REVALIDATE_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Rate limiting (Upstash Redis) — upstash.com → Redis DB → REST API
+# Sin estas vars, checkRateLimit() falla abierto (permite todo) — no bloquea local sin configurar.
+UPSTASH_REDIS_REST_URL=https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.upstash.io
+UPSTASH_REDIS_REST_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,8 @@ REVALIDATE_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Sin estas vars, checkRateLimit() falla abierto (permite todo) — no bloquea local sin configurar.
 UPSTASH_REDIS_REST_URL=https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.upstash.io
 UPSTASH_REDIS_REST_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Captcha invisible (Cloudflare Turnstile) — dash.cloudflare.com → Turnstile → Add site
+# Sin TURNSTILE_SECRET_KEY, /api/contact deja pasar el envío sin validar el captcha (no bloquea local sin configurar).
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=0x4AAAAAAAxxxxxxxxxxxxxx
+TURNSTILE_SECRET_KEY=0x4AAAAAAAxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,24 @@ vercel deploy --prod --yes --force
 
 El `--force` es importante en ese caso puntual — se detectó al menos un caso donde un deploy reusó un manifest de rutas corrupto/desactualizado y una ruta nueva dio 404 en producción pese a compilar bien localmente.
 
+## Seguridad — protección de red (Vercel)
+
+Qué cubre hoy la infraestructura sin ninguna configuración, y qué depende de trabajo de aplicación pendiente (work-item #235).
+
+**Automático, ya activo, gratis en todos los planes (incluido Hobby — el plan de este proyecto):**
+- Mitigación DDoS L3/L4/L7 — activa por defecto, sin configuración, sin costo.
+- Firewall: bloqueo de IPs y reglas custom básicas.
+
+**Manual, gratis, pero hay que activarlo a mano durante un ataque real (no es un toggle "siempre on"):**
+- **Attack Mode** (Dashboard → Firewall → Bot Management → Attack Mode) — página de challenge para todo el tráfico excepto bots conocidos (Google, webhooks) y requests internos del propio proyecto. Gratis, ilimitado, sin impacto en SEO. Usar solo durante un ataque focalizado, no como default permanente (agrega fricción a usuarios reales).
+  - ⚠ APIs standalone o tráfico no reconocido como "browser" pueden no pasar el challenge — si se activa, verificar que `/api/contact` siga funcionando.
+
+**No cubierto por Vercel hoy — depende de las tasks #237/#238 del work-item #235:**
+- Rate limiting a nivel de aplicación (cuántas veces puede la misma IP enviar el formulario de contacto) — Vercel ofrece esto como feature de pago (reglas de rate-limit del WAF), separado del rate limit de aplicación vía Upstash que resuelve #237. Se eligió resolver a nivel de aplicación primero (gratis, más control) antes de pagar por WAF.
+- Captcha en el formulario (que un humano no pueda enviarlo cientos de veces manualmente) — no lo cubre nada de lo anterior, lo resuelve #238 (Turnstile).
+
+**Conclusión:** el sitio ya está protegido contra un ataque de volumen de infraestructura (DDoS) sin hacer nada. Lo que falta es protección a nivel de aplicación (abuso del formulario específicamente) — eso es lo que agregan #237 y #238.
+
 ## ⚠️ Trampa conocida: ruta default de next-intl sin prefijo
 
 `i18n/routing.ts` usa `localePrefix: 'as-needed'` — el locale default (`es`) se sirve **sin prefijo** (`/carta`) vía un rewrite interno del middleware, mientras que las rutas con prefijo explícito (`/en/carta`, y `/es/carta` que en realidad redirige a `/carta`) hacen match directo. Esta asimetría causó dos incidentes de producción (solo reproducibles en Vercel, nunca en local) durante el desarrollo del work-item #118 — ambos se resolvieron, pero la asimetría estructural sigue ahí.

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { saveContact, type ContactTipo, type ContactOrigen } from '@/lib/notion';
 import { checkRateLimit, clientIp } from '@/lib/rate-limit';
+import { verifyTurnstileToken } from '@/lib/turnstile';
 
 const TIPOS_VALIDOS: ContactTipo[] = ['Consulta', 'Sugerencia', 'Reclamo', 'Felicitación'];
 const ORIGENES_VALIDOS: ContactOrigen[] = ['Home', 'Atención Cliente'];
@@ -177,7 +178,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Demasiadas solicitudes, intenta de nuevo en un minuto' }, { status: 429 });
     }
 
-    const { nombre, email, telefono, mensaje, marketing_consent, tipo, origen } = await req.json();
+    const { nombre, email, telefono, mensaje, marketing_consent, tipo, origen, turnstileToken } = await req.json();
 
     if (!nombre?.trim() || !email?.trim() || !mensaje?.trim()) {
       return NextResponse.json({ error: 'Campos requeridos faltantes' }, { status: 400 });
@@ -185,6 +186,18 @@ export async function POST(req: NextRequest) {
 
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       return NextResponse.json({ error: 'Email inválido' }, { status: 400 });
+    }
+
+    if (process.env.TURNSTILE_SECRET_KEY) {
+      if (!turnstileToken || typeof turnstileToken !== 'string') {
+        return NextResponse.json({ error: 'Verificación de seguridad faltante' }, { status: 400 });
+      }
+      const humanVerified = await verifyTurnstileToken(turnstileToken, clientIp(req));
+      if (!humanVerified) {
+        return NextResponse.json({ error: 'Verificación de seguridad fallida, intenta de nuevo' }, { status: 400 });
+      }
+    } else {
+      console.warn('TURNSTILE_SECRET_KEY no configurado — verificación de captcha omitida');
     }
 
     const tipoFinal: ContactTipo = TIPOS_VALIDOS.includes(tipo) ? tipo : 'Consulta';

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,15 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { saveContact, type ContactTipo, type ContactOrigen } from '@/lib/notion';
+import { checkRateLimit, clientIp } from '@/lib/rate-limit';
 
 const TIPOS_VALIDOS: ContactTipo[] = ['Consulta', 'Sugerencia', 'Reclamo', 'Felicitación'];
 const ORIGENES_VALIDOS: ContactOrigen[] = ['Home', 'Atención Cliente'];
-
-function clientIp(req: NextRequest): string | null {
-  const forwarded = req.headers.get('x-forwarded-for');
-  if (forwarded) return forwarded.split(',')[0].trim();
-  return req.headers.get('x-real-ip');
-}
 
 function deviceFromUserAgent(req: NextRequest): 'Mobile' | 'Desktop' {
   const ua = req.headers.get('user-agent') ?? '';
@@ -163,6 +158,11 @@ function confirmationHtml(nombre: string, caso: boolean) {
 
 export async function POST(req: NextRequest) {
   try {
+    const allowed = await checkRateLimit('contact', clientIp(req) ?? 'unknown');
+    if (!allowed) {
+      return NextResponse.json({ error: 'Demasiadas solicitudes, intenta de nuevo en un minuto' }, { status: 429 });
+    }
+
     const { nombre, email, telefono, mensaje, marketing_consent, tipo, origen } = await req.json();
 
     if (!nombre?.trim() || !email?.trim() || !mensaje?.trim()) {

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -13,10 +13,23 @@ function deviceFromUserAgent(req: NextRequest): 'Mobile' | 'Desktop' {
 
 const DESTINATION = 'contacto@dimoe.cl';
 const FROM = 'DiMOE <contacto@dimoe.cl>';
-const LOGO_URL = 'https://dev.dimoe.cl/images/logo-transparent.png';
+const LOGO_URL = 'https://dimoe.cl/images/logo-transparent.png';
 const LOGO_HEADER = `<tr><td style="background:#0D0B09;padding:28px 40px;text-align:center"><img src="${LOGO_URL}" alt="DiMOE" height="42" style="display:block;margin:0 auto;height:42px;width:auto"></td></tr>`;
 
-function notificationHtml(nombre: string, email: string, telefono: string | null, mensaje: string, marketing: boolean, tipo: ContactTipo, origen: ContactOrigen) {
+const HTML_ESCAPES: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+function escapeHtml(str: string): string {
+  return str.replace(/[&<>"']/g, c => HTML_ESCAPES[c]);
+}
+
+function sanitizeHeaderValue(str: string): string {
+  return str.replace(/[\r\n]+/g, ' ').trim();
+}
+
+function notificationHtml(nombreRaw: string, emailRaw: string, telefonoRaw: string | null, mensajeRaw: string, marketing: boolean, tipo: ContactTipo, origen: ContactOrigen) {
+  const nombre = escapeHtml(nombreRaw);
+  const email = escapeHtml(emailRaw);
+  const telefono = telefonoRaw ? escapeHtml(telefonoRaw) : null;
+  const mensaje = escapeHtml(mensajeRaw);
   const fecha = new Date().toLocaleString('es-CL', { timeZone: 'America/Santiago', dateStyle: 'full', timeStyle: 'short' });
   return `<!DOCTYPE html>
 <html lang="es">
@@ -87,7 +100,8 @@ function notificationHtml(nombre: string, email: string, telefono: string | null
 </html>`;
 }
 
-function confirmationHtml(nombre: string, caso: boolean) {
+function confirmationHtml(nombreRaw: string, caso: boolean) {
+  const nombre = escapeHtml(nombreRaw);
   const bodyHtml = caso
     ? `<p style="margin:0 0 16px;font-family:Georgia,serif;font-size:18px;color:#1A1410;line-height:1.5">Hola, ${nombre}.</p>
        <p style="margin:0 0 12px;font-family:Arial,sans-serif;font-size:15px;color:#5A4A3F;line-height:1.7">Nuestro equipo de servicio al cliente ya está revisando tu mensaje personalmente y te responderemos dentro de las próximas 24-48 horas.</p>
@@ -188,7 +202,7 @@ export async function POST(req: NextRequest) {
         from: FROM,
         to: DESTINATION,
         replyTo: email,
-        subject: `[${tipoFinal}] Mensaje de ${nombre}${telefono ? ` · ${telefono}` : ''} — DiMOE`,
+        subject: `[${tipoFinal}] Mensaje de ${sanitizeHeaderValue(nombre)}${telefono ? ` · ${sanitizeHeaderValue(telefono)}` : ''} — DiMOE`,
         html: notificationHtml(nombre, email, telefono ?? null, mensaje, !!marketing_consent, tipoFinal, origenFinal),
       }),
       resend.emails.send({

--- a/app/api/publish/route.ts
+++ b/app/api/publish/route.ts
@@ -2,6 +2,7 @@ import { revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
 import { del, list, put } from '@vercel/blob'
 import { htmlResponse, readBlobJson, secretsMatch } from '@/lib/api-helpers'
+import { checkRateLimit, clientIp } from '@/lib/rate-limit'
 
 export const maxDuration = 60
 
@@ -98,6 +99,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   if (!expected || !secretsMatch(secret, expected)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const allowed = await checkRateLimit('publish', clientIp(req) ?? 'unknown')
+  if (!allowed) {
+    return NextResponse.json({ error: 'too many requests' }, { status: 429 })
   }
 
   try {

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,11 +1,13 @@
 import { revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
+import { secretsMatch } from '@/lib/api-helpers'
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const secret = req.nextUrl.searchParams.get('secret')
+  const secret = req.nextUrl.searchParams.get('secret') ?? ''
+  const expected = process.env.REVALIDATE_SECRET ?? ''
   const tag = req.nextUrl.searchParams.get('tag') ?? 'menu'
 
-  if (!process.env.REVALIDATE_SECRET || secret !== process.env.REVALIDATE_SECRET) {
+  if (!expected || !secretsMatch(secret, expected)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 

--- a/components/sections/ContactForm.tsx
+++ b/components/sections/ContactForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import Script from 'next/script';
 import { useTranslations } from 'next-intl';
 import { trackEvent } from '@/lib/analytics';
 import { trackPixelEvent } from '@/lib/meta-pixel';
@@ -9,6 +10,16 @@ type Status = 'idle' | 'loading' | 'success' | 'error';
 const TIPOS = ['Consulta', 'Sugerencia', 'Reclamo', 'Felicitación'] as const;
 type Tipo = typeof TIPOS[number];
 const GOOGLE_MAPS_URL = process.env.NEXT_PUBLIC_GOOGLE_MAPS_URL ?? 'https://maps.app.goo.gl/cSgXSzJW9VvLttSS7';
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+      reset: (widgetId?: string) => void;
+    };
+  }
+}
 
 type ContactFormProps = {
   origen?: 'Home' | 'Atención Cliente';
@@ -21,6 +32,21 @@ export default function ContactForm({ origen = 'Home', showTipoSelector = false 
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [marketing, setMarketing] = useState(false);
   const [tipo, setTipo] = useState<Tipo | ''>('');
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const [turnstileReady, setTurnstileReady] = useState(false);
+  const turnstileRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!turnstileReady || !TURNSTILE_SITE_KEY || !turnstileRef.current || !window.turnstile) return;
+    widgetIdRef.current = window.turnstile.render(turnstileRef.current, {
+      sitekey: TURNSTILE_SITE_KEY,
+      theme: 'dark',
+      callback: (token: string) => setTurnstileToken(token),
+      'error-callback': () => setTurnstileToken(null),
+      'expired-callback': () => setTurnstileToken(null),
+    });
+  }, [turnstileReady]);
 
   function validate(data: FormData) {
     const errs: Record<string, string> = {};
@@ -32,6 +58,7 @@ export default function ContactForm({ origen = 'Home', showTipoSelector = false 
     const phone = String(data.get('telefono')).trim();
     if (phone && !/^\+?[\d\s\-()]{7,15}$/.test(phone)) errs.telefono = t('err_phone');
     if (!String(data.get('mensaje')).trim()) errs.mensaje = t('err_msg');
+    if (TURNSTILE_SITE_KEY && !turnstileToken) errs.turnstile = t('err_captcha');
     return errs;
   }
 
@@ -54,11 +81,18 @@ export default function ContactForm({ origen = 'Home', showTipoSelector = false 
           marketing_consent: marketing,
           tipo: showTipoSelector ? tipo : undefined,
           origen,
+          turnstileToken,
         }),
       });
       if (res.ok) { setStatus('success'); trackEvent('form_submit_success'); trackPixelEvent('Lead'); }
-      else setStatus('error');
-    } catch { setStatus('error'); }
+      else {
+        setStatus('error');
+        if (window.turnstile) { window.turnstile.reset(widgetIdRef.current); setTurnstileToken(null); }
+      }
+    } catch {
+      setStatus('error');
+      if (window.turnstile) { window.turnstile.reset(widgetIdRef.current); setTurnstileToken(null); }
+    }
   }
 
   const inputStyle: React.CSSProperties = {
@@ -81,6 +115,9 @@ export default function ContactForm({ origen = 'Home', showTipoSelector = false 
 
   return (
     <div style={{ background: '#181310', border: '1px solid #2A2520', borderRadius: '16px', padding: '32px' }}>
+      {TURNSTILE_SITE_KEY && (
+        <Script src="https://challenges.cloudflare.com/turnstile/v0/api.js" strategy="lazyOnload" onLoad={() => setTurnstileReady(true)} />
+      )}
       <h3 style={{ fontFamily: 'var(--font-serif)', fontSize: '20px', fontWeight: 700, color: '#F2EDE4', margin: '0 0 8px' }}>{t('title')}</h3>
       <p style={{ fontSize: '14px', color: '#9B8B7E', margin: '0 0 24px' }}>{t('subtitle')}</p>
 
@@ -184,6 +221,13 @@ export default function ContactForm({ origen = 'Home', showTipoSelector = false 
                 </a>
               </span>
             </label>
+
+            {TURNSTILE_SITE_KEY && (
+              <div>
+                <div ref={turnstileRef} />
+                {errors.turnstile && <p style={{ fontSize: '12px', color: '#E85D5D', margin: '4px 0 0' }}>{errors.turnstile}</p>}
+              </div>
+            )}
 
             {status === 'error' && (
               <p style={{ fontSize: '13px', color: '#E85D5D', margin: 0 }}>

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,35 @@
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+import type { NextRequest } from 'next/server'
+
+const redis =
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+    ? new Redis({
+        url: process.env.UPSTASH_REDIS_REST_URL,
+        token: process.env.UPSTASH_REDIS_REST_TOKEN,
+      })
+    : null
+
+const limiters = {
+  contact: redis
+    ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(5, '1 m'), prefix: 'ratelimit:contact' })
+    : null,
+  publish: redis
+    ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(20, '1 m'), prefix: 'ratelimit:publish' })
+    : null,
+} as const
+
+export type RateLimitScope = keyof typeof limiters
+
+export function clientIp(req: NextRequest): string | null {
+  const forwarded = req.headers.get('x-forwarded-for')
+  if (forwarded) return forwarded.split(',')[0].trim()
+  return req.headers.get('x-real-ip')
+}
+
+export async function checkRateLimit(scope: RateLimitScope, identifier: string): Promise<boolean> {
+  const limiter = limiters[scope]
+  if (!limiter) return true // fail-open: sin credenciales configuradas (ej. local sin .env.local completo)
+  const { success } = await limiter.limit(identifier)
+  return success
+}

--- a/lib/turnstile.ts
+++ b/lib/turnstile.ts
@@ -1,0 +1,15 @@
+const VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+export async function verifyTurnstileToken(token: string, ip?: string | null): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY
+  if (!secret) return false
+
+  const body = new URLSearchParams({ secret, response: token })
+  if (ip) body.set('remoteip', ip)
+
+  const res = await fetch(VERIFY_URL, { method: 'POST', body })
+  if (!res.ok) return false
+
+  const data = (await res.json()) as { success: boolean }
+  return !!data.success
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -102,6 +102,7 @@
     "marketing": "I agree to receive marketing communications and promotions from DiMOE",
     "privacy_link": "Privacy policy",
     "err_phone": "Invalid format. e.g. +56912345678",
+    "err_captcha": "Please confirm you're not a robot",
     "err_tipo": "Select an option",
     "tipo_consulta": "Question",
     "tipo_sugerencia": "Suggestion",

--- a/messages/es.json
+++ b/messages/es.json
@@ -102,6 +102,7 @@
     "marketing": "Acepto recibir comunicaciones de marketing y promociones de DiMOE",
     "privacy_link": "Política de privacidad",
     "err_phone": "Formato inválido. Ej: +56912345678",
+    "err_captcha": "Confirma que no eres un robot",
     "err_tipo": "Selecciona una opción",
     "tipo_consulta": "Consulta",
     "tipo_sugerencia": "Sugerencia",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:e2e": "playwright test --reporter=line"
   },
   "dependencies": {
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/blob": "^2.6.1",
     "framer-motion": "^12",
     "next": "16.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
 
   .:
     dependencies:
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       '@vercel/blob':
         specifier: ^2.6.1
         version: 2.6.1
@@ -956,6 +962,18 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
   '@vercel/blob@2.6.1':
     resolution: {integrity: sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==}
@@ -2317,6 +2335,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -3145,6 +3166,19 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vercel/blob@2.6.1':
     dependencies:
@@ -4740,6 +4774,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@8.3.0: {}
 


### PR DESCRIPTION
Closes #235

## Tasks incluidas
- Closes #236 — fix: comparación insegura de secret en /api/revalidate
- Closes #237 — feat: rate limiting por IP en rutas públicas (Upstash)
- Closes #238 — feat: captcha invisible Turnstile en formularios de contacto
- Closes #239 — chore: documentar protecciones anti-DDoS del plan Vercel actual
- Closes #240 — fix: LOGO_URL hardcodeado a dev.dimoe.cl en emails de /api/contact
- Closes #241 — fix: inyección HTML sin escapar en emails de /api/contact
- Closes #242 — fix: inyección de headers de email vía nombre/telefono en subject de /api/contact

## Resumen
- Rate limiting por IP (Upstash) en /api/contact y /api/publish.
- Captcha invisible Cloudflare Turnstile en los formularios de contacto (Home y Atención Cliente), validado server-side.
- Comparación timing-safe del secret en /api/revalidate.
- Hardening de los emails transaccionales de /api/contact (HTML injection, header injection, logo URL).
- Documentación de las protecciones de red ya activas en Vercel (Hobby plan).

## Test plan
- [ ] `pnpm build` verde
- [ ] Enviar el formulario de contacto (Home y Atención Cliente) y confirmar que el captcha bloquea el envío sin completarlo
- [ ] Confirmar rate limit 429 tras exceder el umbral en /api/contact
- [ ] Confirmar que /api/revalidate sigue funcionando con el secret correcto