### PR TITLE
feat(carta): captura de leads en /carta para nuevos clientes (feature #262)

### DIFF
--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { draftMode } from 'next/headers';
 import Menu from '@/components/sections/Menu';
 import CartaFooter from '@/components/sections/CartaFooter';
+import LeadBanner from '@/components/ui/LeadBanner';
 import { getMenu, getMenuPreview } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
 
@@ -53,6 +54,7 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
       )}
       <Menu menu={menuData} />
       <CartaFooter />
+      <LeadBanner />
     </main>
   );
 }

--- a/app/api/lead-carta/route.ts
+++ b/app/api/lead-carta/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { saveContact } from '@/lib/notion';
+import { checkRateLimit, clientIp } from '@/lib/rate-limit';
+
+function deviceFromUserAgent(req: NextRequest): 'Mobile' | 'Desktop' {
+  const ua = req.headers.get('user-agent') ?? '';
+  return /Mobi|Android|iPhone|iPad/i.test(ua) ? 'Mobile' : 'Desktop';
+}
+
+function dobToIso(value: string): string | null {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(String(value ?? '').trim());
+  if (!match) return null;
+  const [, ddStr, mmStr, yyyyStr] = match;
+  const dd = Number(ddStr);
+  const mm = Number(mmStr);
+  const yyyy = Number(yyyyStr);
+  const date = new Date(Date.UTC(yyyy, mm - 1, dd));
+  const isRealDate = date.getUTCFullYear() === yyyy && date.getUTCMonth() === mm - 1 && date.getUTCDate() === dd;
+  if (!isRealDate || date.getTime() > Date.now()) return null;
+  return `${yyyyStr}-${mmStr}-${ddStr}`;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const allowed = await checkRateLimit('lead-carta', clientIp(req) ?? 'unknown');
+    if (!allowed) {
+      return NextResponse.json({ error: 'Demasiadas solicitudes, intenta de nuevo en un minuto' }, { status: 429 });
+    }
+
+    const { nombre, email, telefono, fechaNacimiento, marketing_consent } = await req.json();
+
+    if (!nombre?.trim() || !email?.trim() || !telefono?.trim()) {
+      return NextResponse.json({ error: 'Campos requeridos faltantes' }, { status: 400 });
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return NextResponse.json({ error: 'Email inválido' }, { status: 400 });
+    }
+
+    const fechaIso = dobToIso(fechaNacimiento);
+    if (!fechaIso) {
+      return NextResponse.json({ error: 'Fecha de nacimiento inválida' }, { status: 400 });
+    }
+
+    await saveContact({
+      nombre,
+      email,
+      telefono,
+      marketing: !!marketing_consent,
+      origen: 'Carta - Nuevo Cliente',
+      ip: clientIp(req),
+      dispositivo: deviceFromUserAgent(req),
+      fechaNacimiento: fechaIso,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('Lead carta API error:', err);
+    return NextResponse.json({ error: 'Error interno' }, { status: 500 });
+  }
+}

--- a/components/ui/CookieBanner.tsx
+++ b/components/ui/CookieBanner.tsx
@@ -27,15 +27,15 @@ export default function CookieBanner() {
   if (!visible) return null;
 
   return (
-    <div role="dialog" aria-label="Cookie notice" style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, background: 'rgba(13,11,9,0.97)', borderTop: '1px solid #2A2520', backdropFilter: 'blur(12px)', padding: '20px 24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '24px', flexWrap: 'wrap' }}>
-      <p style={{ fontSize: '13px', color: '#9B8B7E', margin: 0, maxWidth: '620px', lineHeight: 1.6 }}>
+    <div role="dialog" aria-label="Cookie notice" style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 60, background: 'rgba(13,11,9,0.97)', borderTop: '1px solid #2A2520', backdropFilter: 'blur(12px)', padding: '10px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '14px', flexWrap: 'wrap' }}>
+      <p style={{ fontSize: '11.5px', color: '#9B8B7E', margin: 0, maxWidth: '620px', lineHeight: 1.4 }}>
         {t('text')}{' '}<a href="/privacidad" style={{ color: '#C17A3B', textDecoration: 'none' }}>{t('policy')}</a>.
       </p>
-      <div style={{ display: 'flex', gap: '10px', flexShrink: 0 }}>
-        <button onClick={() => accept('essential')} style={{ background: 'transparent', border: '1px solid #2A2520', color: '#9B8B7E', padding: '9px 18px', borderRadius: '100px', fontSize: '13px', fontWeight: 500, cursor: 'pointer', fontFamily: 'var(--font-sans)' }} onMouseEnter={e => { e.currentTarget.style.borderColor = '#9B8B7E'; e.currentTarget.style.color = '#F2EDE4'; }} onMouseLeave={e => { e.currentTarget.style.borderColor = '#2A2520'; e.currentTarget.style.color = '#9B8B7E'; }}>
+      <div style={{ display: 'flex', gap: '8px', flexShrink: 0 }}>
+        <button onClick={() => accept('essential')} style={{ background: 'transparent', border: '1px solid #2A2520', color: '#9B8B7E', padding: '6px 14px', borderRadius: '100px', fontSize: '12px', fontWeight: 500, cursor: 'pointer', fontFamily: 'var(--font-sans)' }} onMouseEnter={e => { e.currentTarget.style.borderColor = '#9B8B7E'; e.currentTarget.style.color = '#F2EDE4'; }} onMouseLeave={e => { e.currentTarget.style.borderColor = '#2A2520'; e.currentTarget.style.color = '#9B8B7E'; }}>
           {t('essential')}
         </button>
-        <button onClick={() => accept('all')} style={{ background: '#C17A3B', border: 'none', color: '#F2EDE4', padding: '9px 20px', borderRadius: '100px', fontSize: '13px', fontWeight: 600, cursor: 'pointer', fontFamily: 'var(--font-sans)' }} onMouseEnter={e => (e.currentTarget.style.opacity = '0.85')} onMouseLeave={e => (e.currentTarget.style.opacity = '1')}>
+        <button onClick={() => accept('all')} style={{ background: '#C17A3B', border: 'none', color: '#F2EDE4', padding: '6px 16px', borderRadius: '100px', fontSize: '12px', fontWeight: 600, cursor: 'pointer', fontFamily: 'var(--font-sans)' }} onMouseEnter={e => (e.currentTarget.style.opacity = '0.85')} onMouseLeave={e => (e.currentTarget.style.opacity = '1')}>
           {t('accept')}
         </button>
       </div>

--- a/components/ui/LeadBanner.tsx
+++ b/components/ui/LeadBanner.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { getConsent } from './CookieBanner';
+
+const SUBMITTED_KEY = 'dimoe_lead_carta_submitted';
+const DISMISSED_UNTIL_KEY = 'dimoe_lead_carta_dismissed_until';
+const DISMISS_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+type NativeDateInput = HTMLInputElement & { showPicker?: () => void };
+
+function shouldShow(): boolean {
+  if (localStorage.getItem(SUBMITTED_KEY)) return false;
+  const until = Number(localStorage.getItem(DISMISSED_UNTIL_KEY) ?? 0);
+  return Date.now() >= until;
+}
+
+export default function LeadBanner() {
+  const t = useTranslations('leadBanner');
+  const [visible, setVisible] = useState(false);
+  const [status, setStatus] = useState<Status>('idle');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [marketing, setMarketing] = useState(false);
+  const dobRef = useRef<HTMLInputElement>(null);
+  const dobNativeRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    function evaluate() {
+      if (shouldShow()) setVisible(true);
+    }
+    if (getConsent()) {
+      evaluate();
+      return;
+    }
+    window.addEventListener('dimoe:consent-granted', evaluate);
+    document.addEventListener('dimoe:consent-essential', evaluate);
+    return () => {
+      window.removeEventListener('dimoe:consent-granted', evaluate);
+      document.removeEventListener('dimoe:consent-essential', evaluate);
+    };
+  }, []);
+
+  function close() {
+    localStorage.setItem(DISMISSED_UNTIL_KEY, String(Date.now() + DISMISS_COOLDOWN_MS));
+    setVisible(false);
+  }
+
+  function onDobInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const digits = e.target.value.replace(/\D/g, '').slice(0, 8);
+    let out = digits;
+    if (digits.length > 2 && digits.length <= 4) out = `${digits.slice(0, 2)}/${digits.slice(2)}`;
+    else if (digits.length > 4) out = `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4)}`;
+    e.target.value = out;
+  }
+
+  function openCalendar() {
+    const native = dobNativeRef.current as NativeDateInput | null;
+    if (!native) return;
+    if (typeof native.showPicker === 'function') {
+      try { native.showPicker(); } catch { native.focus(); }
+    } else {
+      native.focus();
+    }
+  }
+
+  function syncFromNative(e: React.ChangeEvent<HTMLInputElement>) {
+    const [y, m, d] = e.target.value.split('-');
+    if (y && m && d && dobRef.current) dobRef.current.value = `${d}/${m}/${y}`;
+  }
+
+  function validate(data: FormData) {
+    const errs: Record<string, string> = {};
+    if (!String(data.get('nombre')).trim()) errs.nombre = t('err_name');
+    const email = String(data.get('email')).trim();
+    if (!email) errs.email = t('err_email_req');
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errs.email = t('err_email_inv');
+    const phone = String(data.get('telefono')).trim();
+    if (!phone) errs.telefono = t('err_phone_req');
+    else if (!/^\+?[\d\s\-()]{7,15}$/.test(phone)) errs.telefono = t('err_phone_inv');
+    const fecha = String(data.get('fechaNacimiento')).trim();
+    if (!/^\d{2}\/\d{2}\/\d{4}$/.test(fecha)) errs.fechaNacimiento = t('err_dob');
+    return errs;
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const errs = validate(data);
+    if (Object.keys(errs).length) { setErrors(errs); return; }
+    setErrors({});
+    setStatus('loading');
+    try {
+      const res = await fetch('/api/lead-carta', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nombre: data.get('nombre'),
+          email: data.get('email'),
+          telefono: data.get('telefono'),
+          fechaNacimiento: data.get('fechaNacimiento'),
+          marketing_consent: marketing,
+        }),
+      });
+      if (res.ok) {
+        localStorage.setItem(SUBMITTED_KEY, '1');
+        setStatus('success');
+        setTimeout(() => setVisible(false), 1800);
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  if (!visible) return null;
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%', background: '#0D0B09', border: '1px solid #2A2520',
+    borderRadius: '10px', padding: '11px 13px', fontSize: '13.5px', color: '#F2EDE4',
+    outline: 'none', transition: 'border-color 0.2s', fontFamily: 'var(--font-sans)', boxSizing: 'border-box',
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label={t('title')}
+      style={{
+        position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 55,
+        background: 'rgba(13,11,9,0.98)', backdropFilter: 'blur(16px)',
+        borderTop: '1px solid rgba(193,122,59,0.35)', borderRadius: '20px 20px 0 0',
+        padding: '18px 20px 22px', boxShadow: '0 -18px 44px rgba(0,0,0,0.6)',
+        maxHeight: '42vh', overflowY: 'auto',
+      }}
+    >
+      <div style={{ maxWidth: '480px', margin: '0 auto' }}>
+        {status === 'success' ? (
+          <div style={{ textAlign: 'center', padding: '12px 0' }}>
+            <p style={{ fontFamily: 'var(--font-serif)', fontSize: '16px', fontWeight: 700, color: '#F2EDE4', margin: '0 0 6px' }}>{t('success_title')}</p>
+            <p style={{ fontSize: '13px', color: '#9B8B7E', margin: 0 }}>{t('success_body')}</p>
+          </div>
+        ) : (
+          <>
+            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '12px', marginBottom: '12px' }}>
+              <div>
+                <p style={{ fontFamily: 'var(--font-serif)', fontSize: '16px', fontWeight: 700, margin: '0 0 4px', color: '#F2EDE4' }}>{t('title')}</p>
+                <p style={{ fontSize: '12px', color: '#9B8B7E', margin: 0, lineHeight: 1.5 }}>{t('subtitle')}</p>
+              </div>
+              <button type="button" onClick={close} aria-label={t('close')} style={{
+                flexShrink: 0, width: '28px', height: '28px', borderRadius: '50%', border: '1px solid #2A2520',
+                background: '#0D0B09', color: '#9B8B7E', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+              }}>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} noValidate style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+              <div>
+                <input name="nombre" type="text" placeholder={t('name')} autoComplete="name"
+                  style={{ ...inputStyle, borderColor: errors.nombre ? '#E85D5D' : '#2A2520' }}
+                  onFocus={e => (e.currentTarget.style.borderColor = '#C17A3B')}
+                  onBlur={e => (e.currentTarget.style.borderColor = errors.nombre ? '#E85D5D' : '#2A2520')} />
+                {errors.nombre && <p style={{ fontSize: '11px', color: '#E85D5D', margin: '4px 0 0' }}>{errors.nombre}</p>}
+              </div>
+
+              <div>
+                <div style={{ position: 'relative' }}>
+                  <input ref={dobRef} name="fechaNacimiento" type="text" inputMode="numeric" maxLength={10}
+                    placeholder={t('dob_placeholder')} onChange={onDobInput}
+                    style={{ ...inputStyle, paddingRight: '42px', borderColor: errors.fechaNacimiento ? '#E85D5D' : '#2A2520' }}
+                    onFocus={e => (e.currentTarget.style.borderColor = '#C17A3B')}
+                    onBlur={e => (e.currentTarget.style.borderColor = errors.fechaNacimiento ? '#E85D5D' : '#2A2520')} />
+                  <button type="button" onClick={openCalendar} aria-label={t('open_calendar')} style={{
+                    position: 'absolute', right: '5px', top: '5px', bottom: '5px', width: '34px', border: 'none',
+                    borderRadius: '7px', background: 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    cursor: 'pointer', color: '#C17A3B',
+                  }}>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <rect x="3" y="4" width="18" height="18" rx="2" /><path d="M16 2v4M8 2v4M3 10h18" />
+                    </svg>
+                  </button>
+                  <input ref={dobNativeRef} type="date" tabIndex={-1} aria-hidden="true" onChange={syncFromNative}
+                    style={{ position: 'absolute', opacity: 0, pointerEvents: 'none', width: '1px', height: '1px', left: 0, bottom: 0 }} />
+                </div>
+                {errors.fechaNacimiento && <p style={{ fontSize: '11px', color: '#E85D5D', margin: '4px 0 0' }}>{errors.fechaNacimiento}</p>}
+              </div>
+
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px' }}>
+                <div>
+                  <input name="email" type="email" placeholder={t('email')} autoComplete="email"
+                    style={{ ...inputStyle, borderColor: errors.email ? '#E85D5D' : '#2A2520' }}
+                    onFocus={e => (e.currentTarget.style.borderColor = '#C17A3B')}
+                    onBlur={e => (e.currentTarget.style.borderColor = errors.email ? '#E85D5D' : '#2A2520')} />
+                  {errors.email && <p style={{ fontSize: '11px', color: '#E85D5D', margin: '4px 0 0' }}>{errors.email}</p>}
+                </div>
+                <div>
+                  <input name="telefono" type="tel" placeholder={t('phone')} autoComplete="tel"
+                    style={{ ...inputStyle, borderColor: errors.telefono ? '#E85D5D' : '#2A2520' }}
+                    onFocus={e => (e.currentTarget.style.borderColor = '#C17A3B')}
+                    onBlur={e => (e.currentTarget.style.borderColor = errors.telefono ? '#E85D5D' : '#2A2520')} />
+                  {errors.telefono && <p style={{ fontSize: '11px', color: '#E85D5D', margin: '4px 0 0' }}>{errors.telefono}</p>}
+                </div>
+              </div>
+
+              <label style={{ display: 'flex', alignItems: 'flex-start', gap: '9px', cursor: 'pointer', marginTop: '2px' }}>
+                <div style={{ position: 'relative', flexShrink: 0, marginTop: '1px' }}>
+                  <input type="checkbox" checked={marketing} onChange={e => setMarketing(e.target.checked)}
+                    style={{ position: 'absolute', opacity: 0, width: '15px', height: '15px', cursor: 'pointer' }} />
+                  <div style={{
+                    width: '15px', height: '15px', borderRadius: '4px', border: `1.5px solid ${marketing ? '#C17A3B' : '#2A2520'}`,
+                    background: marketing ? '#C17A3B' : 'transparent', transition: 'all 0.15s', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
+                    {marketing && <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>}
+                  </div>
+                </div>
+                <span style={{ fontSize: '11px', color: '#9B8B7E', lineHeight: 1.5 }}>
+                  {t('marketing')}{' '}
+                  <a href="/privacidad" target="_blank" style={{ color: '#C17A3B', textDecoration: 'none' }}>
+                    ({t('privacy_link')})
+                  </a>
+                </span>
+              </label>
+
+              {status === 'error' && (
+                <p style={{ fontSize: '12px', color: '#E85D5D', margin: 0 }}>{t('error')}</p>
+              )}
+
+              <button type="submit" disabled={status === 'loading'} style={{
+                background: status === 'loading' ? 'rgba(193,122,59,0.6)' : '#C17A3B',
+                color: '#F2EDE4', border: 'none', borderRadius: '100px', padding: '12px',
+                fontSize: '13.5px', fontWeight: 600, cursor: status === 'loading' ? 'not-allowed' : 'pointer',
+                fontFamily: 'var(--font-sans)', marginTop: '2px',
+              }}>
+                {status === 'loading' ? t('sending') : t('submit')}
+              </button>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -10,44 +10,45 @@ function headers() {
 }
 
 export type ContactTipo = 'Consulta' | 'Sugerencia' | 'Reclamo' | 'Felicitación'
-export type ContactOrigen = 'Home' | 'Atención Cliente'
+export type ContactOrigen = 'Home' | 'Atención Cliente' | 'Carta - Nuevo Cliente'
 export type ContactDispositivo = 'Mobile' | 'Desktop'
 
 interface ContactPayload {
   nombre: string
   email: string
   telefono?: string | null
-  mensaje: string
+  mensaje?: string
+  tipo?: ContactTipo
   marketing: boolean
-  tipo: ContactTipo
   origen: ContactOrigen
   ip?: string | null
   dispositivo: ContactDispositivo
+  fechaNacimiento?: string | null
 }
 
 export async function saveContact(data: ContactPayload): Promise<void> {
   const dbId = process.env.NOTION_DB_CONTACTOS
   if (!dbId || !process.env.NOTION_ACCESS_TOKEN) return
 
+  const properties: Record<string, unknown> = {
+    Nombre: { title: [{ text: { content: data.nombre } }] },
+    Email: { email: data.email },
+    Teléfono: data.telefono ? { phone_number: data.telefono } : { phone_number: null },
+    Marketing: { checkbox: data.marketing },
+    Origen: { select: { name: data.origen } },
+    IP: data.ip ? { rich_text: [{ text: { content: data.ip } }] } : { rich_text: [] },
+    Dispositivo: { select: { name: data.dispositivo } },
+    Fecha: { date: { start: new Date().toISOString() } },
+    Estado: { select: { name: 'Nuevo' } },
+  }
+  if (data.mensaje) properties.Mensaje = { rich_text: [{ text: { content: data.mensaje } }] }
+  if (data.tipo) properties.Tipo = { select: { name: data.tipo } }
+  if (data.fechaNacimiento) properties['Fecha de Nacimiento'] = { date: { start: data.fechaNacimiento } }
+
   const res = await fetch(`${NOTION_API}/pages`, {
     method: 'POST',
     headers: headers(),
-    body: JSON.stringify({
-      parent: { database_id: dbId },
-      properties: {
-        Nombre: { title: [{ text: { content: data.nombre } }] },
-        Email: { email: data.email },
-        Teléfono: data.telefono ? { phone_number: data.telefono } : { phone_number: null },
-        Mensaje: { rich_text: [{ text: { content: data.mensaje } }] },
-        Marketing: { checkbox: data.marketing },
-        Tipo: { select: { name: data.tipo } },
-        Origen: { select: { name: data.origen } },
-        IP: data.ip ? { rich_text: [{ text: { content: data.ip } }] } : { rich_text: [] },
-        Dispositivo: { select: { name: data.dispositivo } },
-        Fecha: { date: { start: new Date().toISOString() } },
-        Estado: { select: { name: 'Nuevo' } },
-      },
-    }),
+    body: JSON.stringify({ parent: { database_id: dbId }, properties }),
   })
 
   if (!res.ok) {

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -54,5 +54,6 @@ export async function saveContact(data: ContactPayload): Promise<void> {
   if (!res.ok) {
     const err = await res.json()
     console.error('[Notion] saveContact error:', err)
+    throw new Error('saveContact failed')
   }
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -17,6 +17,9 @@ const limiters = {
   publish: redis
     ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(20, '1 m'), prefix: 'ratelimit:publish' })
     : null,
+  'lead-carta': redis
+    ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(5, '1 m'), prefix: 'ratelimit:lead-carta' })
+    : null,
 } as const
 
 export type RateLimitScope = keyof typeof limiters

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,5 +141,28 @@
     "back": "← Back to home",
     "title": "Privacy Policy",
     "updated": "Last updated"
+  },
+  "leadBanner": {
+    "title": "First time at DiMOE?",
+    "subtitle": "Leave your details and be the first to know about promos and news.",
+    "close": "Close",
+    "name": "Your name",
+    "dob_placeholder": "DD/MM/YYYY",
+    "open_calendar": "Open calendar",
+    "email": "you@email.com",
+    "phone": "+56 9...",
+    "marketing": "I agree to receive marketing communications and promotions from DiMOE",
+    "privacy_link": "privacy policy",
+    "error": "There was a problem saving your details. Please try again.",
+    "sending": "Sending...",
+    "submit": "Save my details",
+    "success_title": "All set!",
+    "success_body": "Thanks — you'll hear about our promos soon.",
+    "err_name": "Name is required",
+    "err_email_req": "Email is required",
+    "err_email_inv": "Invalid email",
+    "err_phone_req": "Phone is required",
+    "err_phone_inv": "Invalid format. e.g. +56912345678",
+    "err_dob": "Invalid date. Format DD/MM/YYYY"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -141,5 +141,28 @@
     "back": "← Volver al inicio",
     "title": "Política de Privacidad",
     "updated": "Última actualización"
+  },
+  "leadBanner": {
+    "title": "¿Primera vez en DiMOE?",
+    "subtitle": "Déjanos tus datos y sé el primero en enterarte de promos y novedades.",
+    "close": "Cerrar",
+    "name": "Tu nombre",
+    "dob_placeholder": "DD/MM/AAAA",
+    "open_calendar": "Abrir calendario",
+    "email": "tu@email.com",
+    "phone": "+56 9...",
+    "marketing": "Acepto recibir comunicaciones y promociones de DiMOE",
+    "privacy_link": "política de privacidad",
+    "error": "Hubo un problema al guardar tus datos. Intenta de nuevo.",
+    "sending": "Enviando...",
+    "submit": "Guardar mis datos",
+    "success_title": "¡Listo!",
+    "success_body": "Gracias — pronto sabrás de nuestras promos.",
+    "err_name": "El nombre es obligatorio",
+    "err_email_req": "El email es obligatorio",
+    "err_email_inv": "Email inválido",
+    "err_phone_req": "El teléfono es obligatorio",
+    "err_phone_inv": "Formato inválido. Ej: +56912345678",
+    "err_dob": "Fecha inválida. Formato DD/MM/AAAA"
   }
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scripts/setup-notion-lead-carta.mjs
+++ b/scripts/setup-notion-lead-carta.mjs
@@ -1,0 +1,88 @@
+/**
+ * One-shot script: extiende la base Notion "Contactos" para el origen "Carta - Nuevo Cliente".
+ * Ejecutar UNA sola vez con: node scripts/setup-notion-lead-carta.mjs
+ *
+ * Requiere NOTION_ACCESS_TOKEN y NOTION_DB_CONTACTOS en .env.local
+ */
+
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+try {
+  const env = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8')
+  for (const line of env.split('\n')) {
+    const [key, ...rest] = line.split('=')
+    if (key && rest.length && !process.env[key.trim()]) {
+      const val = rest.join('=').trim().replace(/^["']|["']$/g, '')
+      if (val) process.env[key.trim()] = val
+    }
+  }
+} catch {
+  // Si no existe .env.local, las vars deben venir del entorno
+}
+
+const TOKEN = process.env.NOTION_ACCESS_TOKEN
+const DB_ID = process.env.NOTION_DB_CONTACTOS
+if (!TOKEN || !DB_ID) {
+  console.error('❌  Falta NOTION_ACCESS_TOKEN o NOTION_DB_CONTACTOS en .env.local')
+  process.exit(1)
+}
+
+const headers = {
+  Authorization: `Bearer ${TOKEN}`,
+  'Content-Type': 'application/json',
+  'Notion-Version': '2022-06-28',
+}
+
+async function notion(method, path, body) {
+  const res = await fetch(`https://api.notion.com/v1${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const data = await res.json()
+  if (!res.ok) throw new Error(`Notion API ${path}: ${JSON.stringify(data)}`)
+  return data
+}
+
+const NEW_ORIGEN = 'Carta - Nuevo Cliente'
+
+async function main() {
+  console.log('🚀  Extendiendo base Contactos para leads de /carta...\n')
+
+  const db = await notion('GET', `/databases/${DB_ID}`)
+  const currentOptions = db.properties.Origen?.select?.options ?? []
+
+  if (currentOptions.some(o => o.name === NEW_ORIGEN)) {
+    console.log(`ℹ  La opción "${NEW_ORIGEN}" ya existe en Origen — no se duplica.`)
+  } else {
+    await notion('PATCH', `/databases/${DB_ID}`, {
+      properties: {
+        Origen: {
+          select: {
+            options: [...currentOptions, { name: NEW_ORIGEN, color: 'purple' }],
+          },
+        },
+      },
+    })
+    console.log(`✓  Opción "${NEW_ORIGEN}" agregada a Origen (preservando las ${currentOptions.length} opciones existentes)`)
+  }
+
+  if (db.properties['Fecha de Nacimiento']) {
+    console.log('ℹ  La propiedad "Fecha de Nacimiento" ya existe — no se recrea.')
+  } else {
+    await notion('PATCH', `/databases/${DB_ID}`, {
+      properties: {
+        'Fecha de Nacimiento': { date: {} },
+      },
+    })
+    console.log('✓  Propiedad "Fecha de Nacimiento" (date) agregada')
+  }
+
+  console.log('\n✅  Listo — base Contactos lista para el origen "Carta - Nuevo Cliente".')
+}
+
+main().catch(err => {
+  console.error('❌ ', err.message)
+  process.exit(1)
+})

--- a/tests/e2e/lead-banner.spec.ts
+++ b/tests/e2e/lead-banner.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+
+const TITLE = /¿Primera vez en DiMOE\?/i;
+const COOKIE_TEXT = /Usamos cookies/i;
+
+test.describe('LeadBanner — captura de leads en /carta', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('/api/lead-carta', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) })
+    );
+  });
+
+  test('espera a que se resuelva el cookie banner y nunca se muestra junto a él', async ({ page }) => {
+    await page.goto('/carta');
+    await expect(page.getByText(COOKIE_TEXT)).toBeVisible();
+    await expect(page.getByText(TITLE)).not.toBeVisible();
+
+    await page.getByRole('button', { name: /Aceptar todo/i }).click();
+    await expect(page.getByText(COOKIE_TEXT)).not.toBeVisible();
+    await expect(page.getByText(TITLE)).toBeVisible();
+  });
+
+  test.describe('con consentimiento de cookies ya resuelto', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript(() => localStorage.setItem('dimoe_cookie_consent', 'all'));
+      await page.goto('/carta');
+      await expect(page.getByText(TITLE)).toBeVisible();
+    });
+
+    test('renderiza todos los campos', async ({ page }) => {
+      await expect(page.getByPlaceholder('Tu nombre')).toBeVisible();
+      await expect(page.getByPlaceholder('DD/MM/AAAA')).toBeVisible();
+      await expect(page.getByPlaceholder('tu@email.com')).toBeVisible();
+      await expect(page.getByPlaceholder('+56 9...')).toBeVisible();
+      await expect(page.getByText(/acepto recibir comunicaciones/i)).toBeVisible();
+      await expect(page.getByRole('button', { name: /guardar mis datos/i })).toBeVisible();
+    });
+
+    test('muestra errores al enviar vacío', async ({ page }) => {
+      await page.getByRole('button', { name: /guardar mis datos/i }).click();
+      await expect(page.getByText(/nombre es obligatorio/i)).toBeVisible();
+      await expect(page.getByText(/email es obligatorio/i)).toBeVisible();
+      await expect(page.getByText(/teléfono es obligatorio/i)).toBeVisible();
+      await expect(page.getByText(/fecha inválida/i)).toBeVisible();
+    });
+
+    test('muestra error con email inválido', async ({ page }) => {
+      await page.getByPlaceholder('Tu nombre').fill('Juan');
+      await page.getByPlaceholder('DD/MM/AAAA').fill('01011990');
+      await page.getByPlaceholder('tu@email.com').fill('no-es-email');
+      await page.getByPlaceholder('+56 9...').fill('+56912345678');
+      await page.getByRole('button', { name: /guardar mis datos/i }).click();
+      await expect(page.getByText(/email inválido/i)).toBeVisible();
+    });
+
+    test('la fecha de nacimiento se autoformatea al tipear', async ({ page }) => {
+      const dob = page.getByPlaceholder('DD/MM/AAAA');
+      await dob.fill('01011990');
+      await expect(dob).toHaveValue('01/01/1990');
+    });
+
+    test('checkbox de marketing es interactivo', async ({ page }) => {
+      const checkbox = page.locator('input[type="checkbox"]');
+      await expect(checkbox).not.toBeChecked();
+      await checkbox.click();
+      await expect(checkbox).toBeChecked();
+    });
+
+    test('happy path: envío exitoso oculta el banner y no vuelve a aparecer', async ({ page }) => {
+      await page.getByPlaceholder('Tu nombre').fill('Juan Pérez');
+      await page.getByPlaceholder('DD/MM/AAAA').fill('01011990');
+      await page.getByPlaceholder('tu@email.com').fill('juan@test.com');
+      await page.getByPlaceholder('+56 9...').fill('+56912345678');
+      await page.getByRole('button', { name: /guardar mis datos/i }).click();
+      await expect(page.getByText(/¡Listo!/i)).toBeVisible();
+
+      const submittedFlag = await page.evaluate(() => localStorage.getItem('dimoe_lead_carta_submitted'));
+      expect(submittedFlag).toBe('1');
+
+      await page.reload();
+      await expect(page.getByText(TITLE)).not.toBeVisible();
+    });
+
+    test('cerrar con X oculta el banner y no reaparece tras recargar (cooldown 24h)', async ({ page }) => {
+      await page.locator('button[aria-label="Cerrar"]').click();
+      await expect(page.getByText(TITLE)).not.toBeVisible();
+
+      const dismissedUntil = await page.evaluate(() => localStorage.getItem('dimoe_lead_carta_dismissed_until'));
+      expect(Number(dismissedUntil)).toBeGreaterThan(Date.now());
+
+      await page.reload();
+      await expect(page.getByText(TITLE)).not.toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
Closes #262

## Tasks incluidas
- Closes #263 — feat: extender base Notion Contactos (origen 'Carta - Nuevo Cliente' + Fecha de Nacimiento)
- Closes #264 — feat: nueva API route /api/lead-carta (rate limit + guardado en Notion)
- Closes #265 — feat: componente LeadBanner (bottom-sheet + persistencia localStorage + coordinación con CookieBanner)
- Closes #266 — feat: montaje en /carta (ambos locales) + i18n
- Closes #267 — test: e2e del LeadBanner (49/49 passed)
- Closes #268 — refactor: reducir tamaño del CookieBanner

## Resumen
- Banner no intrusivo en `/carta` que captura nombre, fecha de nacimiento, correo y teléfono de clientes nuevos, con checkbox de consentimiento de marketing.
- Tercer origen de leads ("Carta - Nuevo Cliente") reconocido en la misma tabla de Notion que ya usan Home y Atención Cliente — sin emails, solo Notion.
- Fecha de nacimiento: input enmascarado DD/MM/AAAA (teclado numérico) + ícono de calendario nativo como alternativa.
- Persistencia 100% client-side: flag permanente tras envío exitoso, cooldown de 24h al cerrar con la X.
- Coordinación con el CookieBanner existente para que nunca se muestren los dos banners a la vez; de paso, CookieBanner se redujo de tamaño.

## Test plan
- [x] `pnpm build` verde
- [x] `pnpm run test:e2e` — 49/49 passed
- [x] Verificado en navegador real: coordinación con CookieBanner, cooldown 24h, flag permanente, validaciones
- [x] `/api/lead-carta` probado end-to-end contra Notion real (lead de prueba creado y archivado tras confirmar)
- [ ] QA manual en `/carta` y `/en/carta` contra el dominio real de Vercel (trampa conocida de locale sin prefijo, CLAUDE.md)