### PR TITLE
fix(carta): invertir orden LeadBanner/CookieBanner y centrar sin scroll

### DIFF
--- a/components/ui/CookieBanner.tsx
+++ b/components/ui/CookieBanner.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { leadBannerWillShow, LEAD_BANNER_RESOLVED_EVENT } from './LeadBanner';
 
 const CONSENT_KEY = 'dimoe_cookie_consent';
 export type ConsentValue = 'all' | 'essential' | null;
@@ -13,9 +15,17 @@ export function getConsent(): ConsentValue {
 
 export default function CookieBanner() {
   const t = useTranslations('cookie');
+  const pathname = usePathname();
   const [visible, setVisible] = useState(false);
 
-  useEffect(() => { if (!getConsent()) setVisible(true); }, []);
+  useEffect(() => {
+    if (getConsent()) return;
+    const onCarta = pathname?.includes('/carta');
+    if (!onCarta || !leadBannerWillShow()) { setVisible(true); return; }
+    function onResolved() { setVisible(true); }
+    window.addEventListener(LEAD_BANNER_RESOLVED_EVENT, onResolved);
+    return () => window.removeEventListener(LEAD_BANNER_RESOLVED_EVENT, onResolved);
+  }, [pathname]);
 
   function accept(value: 'all' | 'essential') {
     localStorage.setItem(CONSENT_KEY, value);

--- a/components/ui/LeadBanner.tsx
+++ b/components/ui/LeadBanner.tsx
@@ -2,16 +2,16 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { getConsent } from './CookieBanner';
 
-const SUBMITTED_KEY = 'dimoe_lead_carta_submitted';
-const DISMISSED_UNTIL_KEY = 'dimoe_lead_carta_dismissed_until';
+export const SUBMITTED_KEY = 'dimoe_lead_carta_submitted';
+export const DISMISSED_UNTIL_KEY = 'dimoe_lead_carta_dismissed_until';
+export const LEAD_BANNER_RESOLVED_EVENT = 'dimoe:lead-banner-resolved';
 const DISMISS_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 type NativeDateInput = HTMLInputElement & { showPicker?: () => void };
 
-function shouldShow(): boolean {
+export function leadBannerWillShow(): boolean {
   if (localStorage.getItem(SUBMITTED_KEY)) return false;
   const until = Number(localStorage.getItem(DISMISSED_UNTIL_KEY) ?? 0);
   return Date.now() >= until;
@@ -27,24 +27,13 @@ export default function LeadBanner() {
   const dobNativeRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    function evaluate() {
-      if (shouldShow()) setVisible(true);
-    }
-    if (getConsent()) {
-      evaluate();
-      return;
-    }
-    window.addEventListener('dimoe:consent-granted', evaluate);
-    document.addEventListener('dimoe:consent-essential', evaluate);
-    return () => {
-      window.removeEventListener('dimoe:consent-granted', evaluate);
-      document.removeEventListener('dimoe:consent-essential', evaluate);
-    };
+    if (leadBannerWillShow()) setVisible(true);
   }, []);
 
   function close() {
     localStorage.setItem(DISMISSED_UNTIL_KEY, String(Date.now() + DISMISS_COOLDOWN_MS));
     setVisible(false);
+    window.dispatchEvent(new Event(LEAD_BANNER_RESOLVED_EVENT));
   }
 
   function onDobInput(e: React.ChangeEvent<HTMLInputElement>) {
@@ -106,6 +95,7 @@ export default function LeadBanner() {
       if (res.ok) {
         localStorage.setItem(SUBMITTED_KEY, '1');
         setStatus('success');
+        window.dispatchEvent(new Event(LEAD_BANNER_RESOLVED_EVENT));
         setTimeout(() => setVisible(false), 1800);
       } else {
         setStatus('error');
@@ -126,16 +116,20 @@ export default function LeadBanner() {
   return (
     <div
       role="dialog"
+      aria-modal="true"
       aria-label={t('title')}
       style={{
-        position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 55,
-        background: 'rgba(13,11,9,0.98)', backdropFilter: 'blur(16px)',
-        borderTop: '1px solid rgba(193,122,59,0.35)', borderRadius: '20px 20px 0 0',
-        padding: '18px 20px 22px', boxShadow: '0 -18px 44px rgba(0,0,0,0.6)',
-        maxHeight: '42vh', overflowY: 'auto',
+        position: 'fixed', inset: 0, zIndex: 55,
+        background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(4px)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: '20px',
       }}
     >
-      <div style={{ maxWidth: '480px', margin: '0 auto' }}>
+      <div style={{
+        width: '100%', maxWidth: '420px', maxHeight: '90vh', overflow: 'hidden',
+        background: 'rgba(13,11,9,0.98)', border: '1px solid rgba(193,122,59,0.35)',
+        borderRadius: '20px', padding: '22px 22px 24px', boxShadow: '0 24px 60px rgba(0,0,0,0.5)',
+      }}>
         {status === 'success' ? (
           <div style={{ textAlign: 'center', padding: '12px 0' }}>
             <p style={{ fontFamily: 'var(--font-serif)', fontSize: '16px', fontWeight: 700, color: '#F2EDE4', margin: '0 0 6px' }}>{t('success_title')}</p>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/e2e/carta.spec.ts
+++ b/tests/e2e/carta.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
 
+// El LeadBanner (ver lead-banner.spec.ts) aparece de inmediato en /carta y es un modal
+// de pantalla completa — estos tests validan navegación de la carta, no el lead banner,
+// así que se pre-marca como ya resuelto para que no bloquee los clicks en las tabs.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('dimoe_lead_carta_submitted', '1'));
+});
+
 test.describe('Carta digital (/carta)', () => {
   test('home de la carta muestra el selector de secciones, sin productos', async ({ page }) => {
     await page.goto('/carta');

--- a/tests/e2e/lead-banner.spec.ts
+++ b/tests/e2e/lead-banner.spec.ts
@@ -10,14 +10,22 @@ test.describe('LeadBanner — captura de leads en /carta', () => {
     );
   });
 
-  test('espera a que se resuelva el cookie banner y nunca se muestra junto a él', async ({ page }) => {
+  test('aparece de inmediato; el cookie banner espera a que se resuelva y nunca se muestran juntos', async ({ page }) => {
     await page.goto('/carta');
-    await expect(page.getByText(COOKIE_TEXT)).toBeVisible();
-    await expect(page.getByText(TITLE)).not.toBeVisible();
-
-    await page.getByRole('button', { name: /Aceptar todo/i }).click();
-    await expect(page.getByText(COOKIE_TEXT)).not.toBeVisible();
     await expect(page.getByText(TITLE)).toBeVisible();
+    await expect(page.getByText(COOKIE_TEXT)).not.toBeVisible();
+
+    await page.locator('button[aria-label="Cerrar"]').click();
+    await expect(page.getByText(TITLE)).not.toBeVisible();
+    await expect(page.getByText(COOKIE_TEXT)).toBeVisible();
+  });
+
+  test('si ya hay consentimiento de cookies guardado, el cookie banner no aparece tras resolver el lead banner', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('dimoe_cookie_consent', 'all'));
+    await page.goto('/carta');
+    await expect(page.getByText(TITLE)).toBeVisible();
+    await page.locator('button[aria-label="Cerrar"]').click();
+    await expect(page.getByText(COOKIE_TEXT)).not.toBeVisible();
   });
 
   test.describe('con consentimiento de cookies ya resuelto', () => {


### PR DESCRIPTION
## Resumen
Ajuste de UX pedido tras el lanzamiento a producción:
- `LeadBanner` ahora aparece de inmediato al entrar a `/carta` (ya no espera el cookie banner).
- Pasa de bottom-sheet a modal centrado en pantalla, sin scroll interno (antes: `maxHeight: 42vh` + scroll).
- `CookieBanner` ahora espera a que se resuelva el `LeadBanner` (cierre con X o envío exitoso) antes de mostrarse en `/carta` — en el resto del sitio sigue igual que antes (sin esperar nada).

## Por qué
Feedback directo del dev tras ver el flujo real: "primero aparece cookies y después el formulario, debiera ser al revés" + "el formulario está muy muy abajo, debe estar centrado" + "que no sea scrolleable".

## Test plan
- [x] `tsc --noEmit` limpio
- [x] `pnpm run test:e2e` — 50/50 passed (agregado init-script en `carta.spec.ts` para que el LeadBanner no bloquee tests de navegación de menú, que ahora es modal de pantalla completa)
- [x] Verificado visualmente en mobile (390px) y desktop — capturas revisadas