### PR TITLE
fix(seo): canonical propio en páginas hijas (#200) — fix #199

### DIFF
--- a/app/[locale]/atencion-cliente/page.tsx
+++ b/app/[locale]/atencion-cliente/page.tsx
@@ -12,6 +12,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     description: isEn
       ? 'Tell us about your visit to DiMOE — questions, suggestions or complaints reviewed personally by our team.'
       : 'Cuéntanos cómo fue tu visita a DiMOE — dudas, sugerencias o reclamos revisados personalmente por nuestro equipo.',
+    alternates: {
+      canonical: isEn ? 'https://dimoe.cl/en/atencion-cliente' : 'https://dimoe.cl/atencion-cliente',
+    },
   };
 }
 

--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -18,6 +18,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     description: isEn
       ? 'Full menu: Neapolitan pizzas, artisan pasta, craft cocktails, desserts and bar. Prices in CLP.'
       : 'Carta completa: pizzas napolitanas, pastas artesanales, cócteles de autor, postres y bar. Precios en CLP.',
+    alternates: {
+      canonical: isEn ? 'https://dimoe.cl/en/carta' : 'https://dimoe.cl/carta',
+    },
   };
 }
 

--- a/app/[locale]/nosotros/page.tsx
+++ b/app/[locale]/nosotros/page.tsx
@@ -10,6 +10,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     description: isEn
       ? 'The story behind DiMOE: a Neapolitan pizzeria born in Paine, Chile, recognized as the 2nd best pizza in the Metropolitan Region by The Top Chile 2025.'
       : 'La historia de DiMOE: una pizzería napolitana nacida en Paine, Chile, reconocida como la 2° mejor pizza de la Región Metropolitana por The Top Chile 2025.',
+    alternates: {
+      canonical: isEn ? 'https://dimoe.cl/en/nosotros' : 'https://dimoe.cl/nosotros',
+    },
   };
 }
 

--- a/app/[locale]/privacidad/page.tsx
+++ b/app/[locale]/privacidad/page.tsx
@@ -1,11 +1,18 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-export const metadata: Metadata = {
-  title: 'Política de Privacidad — DiMOE',
-  description: 'Política de privacidad de DiMOE Pizzería y Restobar conforme a la Ley 21.719 de Chile.',
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const isEn = locale === 'en';
+  return {
+    title: 'Política de Privacidad — DiMOE',
+    description: 'Política de privacidad de DiMOE Pizzería y Restobar conforme a la Ley 21.719 de Chile.',
+    robots: { index: false, follow: false },
+    alternates: {
+      canonical: isEn ? 'https://dimoe.cl/en/privacidad' : 'https://dimoe.cl/privacidad',
+    },
+  };
+}
 
 const LAST_UPDATED = '1 de junio de 2025';
 

--- a/app/[locale]/resenas/page.tsx
+++ b/app/[locale]/resenas/page.tsx
@@ -11,6 +11,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     description: isEn
       ? 'Read what customers say about DiMOE, the award-winning Neapolitan pizza restaurant in Paine, Chile.'
       : 'Lee lo que dicen los clientes sobre DiMOE, la pizzería napolitana premiada en Paine, Chile.',
+    alternates: {
+      canonical: isEn ? 'https://dimoe.cl/en/resenas' : 'https://dimoe.cl/resenas',
+    },
   };
 }
 


### PR DESCRIPTION
## Resumen
- Cada página hija (`/carta`, `/nosotros`, `/atencion-cliente`, `/resenas`, `/privacidad`) ahora declara su propio `alternates.canonical` en `generateMetadata`, en vez de heredar el canonical del layout raíz (que apuntaba siempre a la home).
- Canonical correcto por locale: sin prefijo para `es` (default), con `/en/...` para inglés — consistente con `localePrefix: 'as-needed'` de next-intl.

## Por qué importa ahora
Con `dimoe.cl` ya migrado desde GoDaddy y siendo indexable de verdad por Google, un canonical incorrecto en páginas hijas puede hacer que Google las ignore a favor de la home.

## Test plan
- [x] `pnpm test:e2e` corrido completo contra esta rama (mergeada con `dev` al día): 47/50 verde.
- [x] Las 3 fallas restantes (`atencion-cliente.spec.ts` x2, `carta.spec.ts` "home de la carta...") se confirmaron **pre-existentes en `dev` limpio**, sin relación con este cambio — no son una regresión de este PR.

Closes #199
Closes #200

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>