### PR TITLE
chore(security): desactivar header X-Powered-By (#270)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ import createNextIntlPlugin from 'next-intl/plugin';
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
 const nextConfig: NextConfig = {
+  poweredByHeader: false,
 
   async headers() {
     return [


### PR DESCRIPTION
## Resumen
Paso parcial de #270 — desactiva el header `X-Powered-By: Next.js` (`poweredByHeader: false`), que exponía innecesariamente el framework.

**No cierra #270** — falta la parte principal (header `Content-Security-Policy`), que requiere inventariar todos los dominios externos que carga el sitio (fonts, GA, Meta Pixel, Google Maps/Places) antes de escribir la política, sin romper nada existente.

Ref #270

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>