### PR TITLE
fix(tests): warm-up de rutas evita flake de arranque en frío en el gate

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ const PORT = Number(process.env.PLAYWRIGHT_E2E_PORT ?? 39847);
 
 export default defineConfig({
   testDir: 'tests/e2e',
+  globalSetup: './tests/e2e/global-setup.ts',
   timeout: 30_000,
   workers: 2,
   reporter: 'line',

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,21 @@
+import type { FullConfig } from '@playwright/test';
+
+// next dev compila cada ruta on-demand en la primera request — con 2 workers en
+// paralelo, dos rutas frías compilando a la vez pueden superar el timeout de un test.
+// Precompilar acá, antes de que arranquen los workers, evita esa carrera de arranque.
+const ROUTES_TO_WARM = ['/', '/carta', '/atencion-cliente', '/nosotros', '/resenas', '/privacidad'];
+
+export default async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL ?? 'http://localhost:39847';
+
+  for (const route of ROUTES_TO_WARM) {
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        const res = await fetch(`${baseURL}${route}`, { signal: AbortSignal.timeout(60_000) });
+        if (res.ok) break;
+      } catch {
+        if (attempt === 3) throw new Error(`No se pudo precompilar ${route} tras 3 intentos`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 2 specs del gate E2E fallaban intermitentemente (`atencion-cliente.spec.ts`, `carta.spec.ts`) con timeout/`net::ERR_ABORTED` al ser el primer test de cada worker.
- Confirmado con `--workers=1` que no es un bug de producto (12/12 verde siempre) — es `next dev` compilando rutas on-demand, y 2 workers pidiendo rutas frías a la vez pueden superar el timeout de 30s del test.
- Fix: `tests/e2e/global-setup.ts` precompila las rutas clave antes de que arranquen los workers en paralelo. Sin bajar workers a 1, sin tocar código de producto.

Closes #281

## Test plan
- [x] `pnpm tsc --noEmit` limpio
- [x] Suite completa (`CI=true`, 2 workers, server fresco): 50/50 verde en 2 corridas consecutivas