### PR TITLE
test(carta): specs Playwright para el flujo de preview de /carta

### DIFF
--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
-import { draftMode } from 'next/headers';
+import { draftMode, headers } from 'next/headers';
 import Menu from '@/components/sections/Menu';
 import CartaFooter from '@/components/sections/CartaFooter';
 import LeadBanner from '@/components/ui/LeadBanner';
 import { getMenu, getMenuPreview } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
+import { getE2EPreviewFixture, type E2EPreviewVariant } from '@/lib/menu-e2e-fixture';
 
 export const maxDuration = 30;
 
@@ -26,7 +27,20 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
   const { locale } = await params;
   const isEn = locale === 'en';
   const { isEnabled: isPreview } = await draftMode();
-  const notionData = isPreview ? await getMenuPreview(locale) : await getMenu(locale);
+
+  const e2eVariant = process.env.PLAYWRIGHT_E2E === 'true'
+    ? ((await headers()).get('x-e2e-menu-fixture') as E2EPreviewVariant | null)
+    : null;
+
+  let notionData: Awaited<ReturnType<typeof getMenu>>;
+  let publishedData: Awaited<ReturnType<typeof getMenu>>;
+  if (isPreview && e2eVariant) {
+    ({ notionData, publishedData } = getE2EPreviewFixture(e2eVariant));
+  } else {
+    notionData = isPreview ? await getMenuPreview(locale) : await getMenu(locale);
+    publishedData = isPreview ? await getMenu(locale) : null;
+  }
+
   const previewFetchFailed = isPreview && notionData === null;
   const menuData = notionData
     ? {
@@ -36,7 +50,6 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
       }
     : FALLBACK_MENU;
 
-  const publishedData = isPreview ? await getMenu(locale) : null;
   const hasUnpublishedChanges = isPreview && !previewFetchFailed && JSON.stringify(notionData) !== JSON.stringify(publishedData);
 
   return (

--- a/lib/menu-e2e-fixture.ts
+++ b/lib/menu-e2e-fixture.ts
@@ -1,0 +1,36 @@
+import type { MenuTab, MenuGroup } from './menu'
+
+/**
+ * Fixtures del flujo de preview para el gate E2E (#201/#202) — evita que los
+ * tests dependan de credenciales/datos reales de Notion o Vercel Blob. Solo se
+ * activan si PLAYWRIGHT_E2E=true (seteado únicamente por playwright.config.ts)
+ * y el request trae el header x-e2e-menu-fixture, así que nunca se ejecutan
+ * fuera del gate.
+ */
+export type E2EPreviewVariant = 'same' | 'diff' | 'notion-down'
+
+function fixtureMenu(marker: string): Record<MenuTab, MenuGroup[]> {
+  return {
+    ENTRADAS: [{ items: [{ name: `E2E fixture — ${marker}`, price: 1000 }] }],
+    PIZZAS: [],
+    FONDOS: [],
+    POSTRES: [],
+    BAR: [],
+    VINOS: [],
+    SEMANAL: [],
+  }
+}
+
+export function getE2EPreviewFixture(variant: E2EPreviewVariant): {
+  notionData: Record<MenuTab, MenuGroup[]> | null
+  publishedData: Record<MenuTab, MenuGroup[]> | null
+} {
+  if (variant === 'notion-down') {
+    return { notionData: null, publishedData: fixtureMenu('published') }
+  }
+  if (variant === 'diff') {
+    return { notionData: fixtureMenu('preview'), publishedData: fixtureMenu('published') }
+  }
+  const same = fixtureMenu('same')
+  return { notionData: same, publishedData: same }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+import { E2E_PUBLISH_SECRET } from './tests/e2e/e2e-constants';
 
 const PORT = Number(process.env.PLAYWRIGHT_E2E_PORT ?? 39847);
 
@@ -14,5 +15,9 @@ export default defineConfig({
     port: PORT,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    env: {
+      PLAYWRIGHT_E2E: 'true',
+      PUBLISH_SECRET: process.env.PUBLISH_SECRET ?? E2E_PUBLISH_SECRET,
+    },
   },
 });

--- a/tests/e2e/carta-preview.spec.ts
+++ b/tests/e2e/carta-preview.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { E2E_PUBLISH_SECRET } from './e2e-constants';
+
+async function activatePreview(page: import('@playwright/test').Page) {
+  await page.goto(`/api/preview?secret=${E2E_PUBLISH_SECRET}`);
+}
+
+function withFixtureHeader(page: import('@playwright/test').Page, variant: 'same' | 'diff' | 'notion-down') {
+  return page.route('**/carta', route =>
+    route.continue({ headers: { ...route.request().headers(), 'x-e2e-menu-fixture': variant } })
+  );
+}
+
+test.describe('Flujo de preview de /carta (Draft Mode)', () => {
+  // El LeadBanner (ver lead-banner.spec.ts) es un modal de pantalla completa que
+  // aparece de inmediato en /carta y taparía el link "Salir de preview" — estos
+  // tests validan el flujo de preview, no el lead banner.
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('dimoe_lead_carta_submitted', '1'));
+  });
+
+  test('activar preview via /api/preview habilita Draft Mode y redirige a /carta', async ({ page, context }) => {
+    await activatePreview(page);
+    await expect(page).toHaveURL(/\/carta$/);
+
+    const cookies = await context.cookies();
+    expect(cookies.some(c => c.name === '__prerender_bypass')).toBe(true);
+  });
+
+  test('preview activo sin diffs muestra "Modo preview activo"', async ({ page }) => {
+    await activatePreview(page);
+    await withFixtureHeader(page, 'same');
+    await page.goto('/carta');
+
+    await expect(page.getByText(/modo preview activo/i)).toBeVisible();
+    await expect(page.getByText(/hay cambios sin publicar/i)).not.toBeVisible();
+    await expect(page.getByText(/no se pudo conectar con notion/i)).not.toBeVisible();
+  });
+
+  test('preview activo con diffs muestra "Hay cambios sin publicar"', async ({ page }) => {
+    await activatePreview(page);
+    await withFixtureHeader(page, 'diff');
+    await page.goto('/carta');
+
+    await expect(page.getByText(/hay cambios sin publicar/i)).toBeVisible();
+  });
+
+  test('preview activo con Notion caído muestra "No se pudo conectar con Notion"', async ({ page }) => {
+    await activatePreview(page);
+    await withFixtureHeader(page, 'notion-down');
+    await page.goto('/carta');
+
+    await expect(page.getByText(/no se pudo conectar con notion/i)).toBeVisible();
+  });
+
+  test('salir de preview via /api/preview-exit borra la cookie y el banner desaparece', async ({ page, context }) => {
+    await activatePreview(page);
+    await withFixtureHeader(page, 'same');
+    await page.goto('/carta');
+    await expect(page.getByText(/modo preview activo/i)).toBeVisible();
+
+    await page.getByRole('link', { name: /salir de preview/i }).click();
+
+    const cookies = await context.cookies();
+    expect(cookies.some(c => c.name === '__prerender_bypass')).toBe(false);
+    await expect(page.getByText(/modo preview activo/i)).not.toBeVisible();
+  });
+});

--- a/tests/e2e/e2e-constants.ts
+++ b/tests/e2e/e2e-constants.ts
@@ -1,0 +1,3 @@
+// Secret de PUBLISH_SECRET usado solo dentro del gate E2E (playwright.config.ts lo
+// setea en el proceso del servidor) — nunca es un secret real, no protege nada.
+export const E2E_PUBLISH_SECRET = 'e2e-test-secret';

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,9 +1,19 @@
 import type { FullConfig } from '@playwright/test';
+import { E2E_PUBLISH_SECRET } from './e2e-constants';
 
 // next dev compila cada ruta on-demand en la primera request — con 2 workers en
 // paralelo, dos rutas frías compilando a la vez pueden superar el timeout de un test.
 // Precompilar acá, antes de que arranquen los workers, evita esa carrera de arranque.
-const ROUTES_TO_WARM = ['/', '/carta', '/atencion-cliente', '/nosotros', '/resenas', '/privacidad'];
+const ROUTES_TO_WARM = [
+  '/',
+  '/carta',
+  '/atencion-cliente',
+  '/nosotros',
+  '/resenas',
+  '/privacidad',
+  `/api/preview?secret=${E2E_PUBLISH_SECRET}`,
+  '/api/preview-exit',
+];
 
 export default async function globalSetup(config: FullConfig) {
   const baseURL = config.projects[0]?.use?.baseURL ?? 'http://localhost:39847';


### PR DESCRIPTION
## Summary
- Cero cobertura E2E existía para el flujo de preview (Draft Mode + banner) agregado por #118 — hallazgo P3 de la auditoría Fable.
- 5 specs nuevos en `tests/e2e/carta-preview.spec.ts`: activar preview (cookie + redirect), los 3 estados del banner ("Modo preview activo" / "Hay cambios sin publicar" / "No se pudo conectar con Notion"), y salir de preview.
- Sin depender de credenciales ni datos reales de Notion/Blob: un test-seam gateado por `PLAYWRIGHT_E2E=true` (solo seteado en `playwright.config.ts`) lee un header `x-e2e-menu-fixture` inyectado vía interceptación de Playwright (`route.continue`) para elegir entre 3 fixtures fijas — inerte fuera del gate E2E, no toca `getMenu`/`getMenuPreview` reales.
- Extendí `tests/e2e/global-setup.ts` (del fix de flake en #282) para precompilar también `/api/preview` y `/api/preview-exit`.

Closes #201
Closes #202

## Test plan
- [x] `pnpm tsc --noEmit` limpio
- [x] Suite completa (`CI=true`, 2 workers, server fresco): 55/55 verde en 2 corridas consecutivas