### PR TITLE
chore(security): Content-Security-Policy en modo report-only

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,32 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
+// Inventario de dominios externos que carga el navegador (no server-side: Notion,
+// Resend, Vercel Blob y la Places API de Google se llaman desde las API routes, no
+// desde el cliente, así que no entran acá). GA4, Meta Pixel y Turnstile se activan
+// solo si su env var pública está seteada, pero se allowlistean igual porque el
+// código ya los soporta. Fuentes van por next/font/google (self-hosted en build),
+// por eso no hace falta fonts.googleapis.com/fonts.gstatic.com en runtime.
+//
+// Report-Only a propósito: este proyecto no tiene ambiente de staging (dev.dimoe.cl
+// ES producción, ver CLAUDE.md), así que no hay forma de probar una CSP enforcing
+// sin arriesgar romper GA4/Turnstile/Meta Pixel en el sitio real. Cuando se confirme
+// unas semanas sin violaciones reales (DevTools de usuarios reales o un endpoint de
+// report-uri), pasar a Content-Security-Policy sin -Report-Only.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://challenges.cloudflare.com https://connect.facebook.net",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https://www.facebook.com",
+  "font-src 'self' data:",
+  "connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://challenges.cloudflare.com https://www.facebook.com",
+  "frame-src https://challenges.cloudflare.com https://www.google.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'self'",
+].join('; ');
+
 const nextConfig: NextConfig = {
   poweredByHeader: false,
 
@@ -16,6 +42,7 @@ const nextConfig: NextConfig = {
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
           { key: 'X-DNS-Prefetch-Control', value: 'on' },
+          { key: 'Content-Security-Policy-Report-Only', value: CSP },
         ],
       },
     ];


### PR DESCRIPTION
## Summary
- Inventario completo de dominios externos que carga el **navegador** (Notion/Resend/Blob/Places API son server-side, no entran en CSP del cliente): GA4 (`googletagmanager.com`), Turnstile (`challenges.cloudflare.com`), Meta Pixel (`connect.facebook.net`/`facebook.com`) y el iframe de Google Maps (`www.google.com`).
- Las fuentes van por `next/font/google` (self-hosted en build) — no hace falta whitelistear `fonts.googleapis.com`/`fonts.gstatic.com` en runtime.
- **Report-Only a propósito**: este proyecto no tiene staging (`dev.dimoe.cl` es producción real) — no hay forma segura de validar una CSP enforcing sin arriesgar romper GA4/Turnstile/Meta Pixel para usuarios reales. Pasar a enforcing es un follow-up explícito una vez confirmado sin violaciones en tráfico real.
- `style-src`/`script-src` incluyen `'unsafe-inline'` — el sitio usa extensivamente `style={{}}` inline y Next.js inyecta scripts de hidratación; una CSP con nonces sería un cambio mucho más invasivo (middleware + threading de nonce por todo el árbol) fuera de alcance de este chore.

Closes #270 (parcial — X-Powered-By ya se resolvió en #277; esto cierra el resto)

## Test plan
- [x] `pnpm tsc --noEmit` limpio
- [x] Suite completa E2E: 50/50 verde, **cero violaciones CSP en consola** (grep de "content-security-policy|refused to|csp" sobre toda la corrida) en todo el sitio, incluyendo el iframe de Google Maps que siempre renderiza