### PR TITLE
feat(carta): badge de texto AGOTADO junto al nombre

### DIFF
--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -495,6 +495,16 @@ export default function Menu({ menu }: Props) {
                               }}>
                                 {item.name}
                               </span>
+                              {item.agotado && (
+                                <span style={{
+                                  ...typography.badge,
+                                  color: '#C1503B',
+                                  border: '1px solid rgba(193,80,59,0.4)',
+                                  borderRadius: '100px', padding: '2px 8px', whiteSpace: 'nowrap',
+                                }}>
+                                  AGOTADO
+                                </span>
+                              )}
                               {item.badge && (
                                 <span style={{
                                   ...typography.badge,

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -492,6 +492,9 @@ export default function Menu({ menu }: Props) {
                               <span style={{
                                 ...(isCompact ? typography.itemNameCompact : typography.itemName),
                                 color: isVinosPointer ? '#C17A3B' : '#F2EDE4',
+                                textDecoration: item.agotado ? 'line-through' : undefined,
+                                textDecorationColor: item.agotado ? 'rgba(242,237,228,0.4)' : undefined,
+                                opacity: item.agotado ? 0.7 : undefined,
                               }}>
                                 {item.name}
                               </span>

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -16,6 +16,7 @@ export type MenuItem = {
   picante?: boolean
   veganizable?: boolean
   libreDeGluten?: boolean
+  agotado?: boolean
 }
 
 export type MenuGroup = {
@@ -42,6 +43,7 @@ type NotionMenuPage = {
     Picante?: { checkbox: boolean }
     Veganizable?: { checkbox: boolean }
     'Libre de Gluten'?: { checkbox: boolean }
+    Agotado?: { checkbox: boolean }
     // Orden de dos niveles: 'Orden Sección' ordena los grupos entre sí
     // (Happy Hour, Cervezas, ...) y 'Orden' ordena los productos dentro de
     // su propia sección — así reordenar un producto nunca requiere tocar
@@ -112,6 +114,7 @@ function parseMenuPages(
       picante: p.Picante?.checkbox || undefined,
       veganizable: p.Veganizable?.checkbox || undefined,
       libreDeGluten: p['Libre de Gluten']?.checkbox || undefined,
+      agotado: p.Agotado?.checkbox || undefined,
     }
 
     groups.get(subcat)!.push(item)


### PR DESCRIPTION
## Summary
- Nueva columna checkbox `Agotado` en la DB Notion "Menú" (agregada vía API, mismo camino usado para Veganizable/Libre de Gluten).
- `MenuItem.agotado` parseado igual que los demás checkboxes de badge existentes.
- Render: pill de texto siempre visible ("AGOTADO", rojo) junto al nombre — distinto del patrón ícono+tooltip de Vegetariano/Picante/Veganizable/Libre de Gluten porque el pedido explícito era que el badge "diga" el texto. Convive con el badge de marketing existente (Tag/Badge) como campo independiente.
- Sin marcar productos reales como agotados — decisión de contenido del dueño (mismo criterio que Veganizable/Libre de Gluten).

Verificado visualmente con screenshots mobile/desktop (fallback local temporal, revertido antes de commitear) antes de abrir el PR.

Closes #285

## Test plan
- [x] `pnpm tsc --noEmit` limpio
- [x] Suite completa E2E: 55/55 verde
- [x] Verificación visual: pill "AGOTADO" conviviendo con badge de marketing, mobile y desktop