### PR TITLE
test(carta): spec E2E para el badge AGOTADO

### DIFF
--- a/lib/menu-e2e-fixture.ts
+++ b/lib/menu-e2e-fixture.ts
@@ -11,7 +11,12 @@ export type E2EPreviewVariant = 'same' | 'diff' | 'notion-down'
 
 function fixtureMenu(marker: string): Record<MenuTab, MenuGroup[]> {
   return {
-    ENTRADAS: [{ items: [{ name: `E2E fixture — ${marker}`, price: 1000 }] }],
+    ENTRADAS: [{
+      items: [
+        { name: `E2E fixture — ${marker}`, price: 1000 },
+        { name: `E2E fixture — ${marker} (agotado)`, price: 1000, agotado: true },
+      ],
+    }],
     PIZZAS: [],
     FONDOS: [],
     POSTRES: [],

--- a/tests/e2e/carta-preview.spec.ts
+++ b/tests/e2e/carta-preview.spec.ts
@@ -65,4 +65,19 @@ test.describe('Flujo de preview de /carta (Draft Mode)', () => {
     expect(cookies.some(c => c.name === '__prerender_bypass')).toBe(false);
     await expect(page.getByText(/modo preview activo/i)).not.toBeVisible();
   });
+
+  // Reusa el mismo fixture del flujo de preview (#201/#202) para probar el badge
+  // AGOTADO (#285) sin depender de datos reales de Notion — FALLBACK_MENU no
+  // tiene ningún ítem agotado hoy y no corresponde marcar uno real solo para test.
+  test('ítem con agotado=true muestra el pill "AGOTADO" y el nombre tachado', async ({ page }) => {
+    await activatePreview(page);
+    await withFixtureHeader(page, 'same');
+    await page.goto('/carta');
+    await page.getByRole('button', { name: /ENTRADAS/ }).first().click();
+
+    const itemName = page.getByText(/E2E fixture — same \(agotado\)/i);
+    await expect(itemName).toBeVisible();
+    await expect(itemName).toHaveCSS('text-decoration-line', 'line-through');
+    await expect(page.getByText('AGOTADO', { exact: true })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- El PR original del badge AGOTADO (#286) solo tenía verificación visual manual — gap detectado al preguntar si se había testeado E2E.
- Reusa el fixture del flujo de preview (#201/#202, mismo mecanismo de header de Playwright) para probar el pill "AGOTADO" + el tachado del nombre, sin depender de datos reales de Notion.
- Se agregó un segundo ítem `agotado: true` al fixture `same` en `lib/menu-e2e-fixture.ts`.

Closes #285

## Test plan
- [x] `pnpm tsc --noEmit` limpio
- [x] Suite completa E2E: 56/56 verde en 2 corridas consecutivas