### PR TITLE
feat(carta): ocultar MENÚ SEMANAL fuera de horario

### DIFF
--- a/app/[locale]/carta/page.tsx
+++ b/app/[locale]/carta/page.tsx
@@ -3,7 +3,7 @@ import { draftMode, headers } from 'next/headers';
 import Menu from '@/components/sections/Menu';
 import CartaFooter from '@/components/sections/CartaFooter';
 import LeadBanner from '@/components/ui/LeadBanner';
-import { getMenu, getMenuPreview } from '@/lib/menu';
+import { getMenu, getMenuPreview, shouldShowSemanal } from '@/lib/menu';
 import { FALLBACK_MENU } from '@/lib/menu-fallback';
 import { getE2EPreviewFixture, type E2EPreviewVariant } from '@/lib/menu-e2e-fixture';
 
@@ -28,9 +28,11 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
   const isEn = locale === 'en';
   const { isEnabled: isPreview } = await draftMode();
 
-  const e2eVariant = process.env.PLAYWRIGHT_E2E === 'true'
-    ? ((await headers()).get('x-e2e-menu-fixture') as E2EPreviewVariant | null)
-    : null;
+  const isE2E = process.env.PLAYWRIGHT_E2E === 'true'
+  const e2eHeaders = isE2E ? await headers() : null;
+  const e2eVariant = e2eHeaders?.get('x-e2e-menu-fixture') as E2EPreviewVariant | null;
+  const e2eNow = e2eHeaders?.get('x-e2e-now');
+  const showSemanal = shouldShowSemanal(e2eNow ? new Date(e2eNow) : undefined);
 
   let notionData: Awaited<ReturnType<typeof getMenu>>;
   let publishedData: Awaited<ReturnType<typeof getMenu>>;
@@ -68,7 +70,7 @@ export default async function CartaPage({ params }: { params: Promise<{ locale: 
           </a>
         </div>
       )}
-      <Menu menu={menuData} />
+      <Menu menu={menuData} showSemanal={showSemanal} />
       <CartaFooter />
       <LeadBanner />
     </main>

--- a/components/sections/Menu.tsx
+++ b/components/sections/Menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useState, useEffect, useRef } from 'react';
+import { Fragment, useState, useEffect, useMemo, useRef } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslations, useLocale } from 'next-intl';
@@ -12,7 +12,7 @@ import MenuSubtabs from './MenuSubtabs';
 import ScrollFadeEdges from './ScrollFadeEdges';
 import { useScrollFade } from './use-scroll-fade';
 
-const TABS: MenuTab[] = ['ENTRADAS', 'PIZZAS', 'FONDOS', 'POSTRES', 'BAR', 'VINOS', 'SEMANAL'];
+const ALL_TABS: MenuTab[] = ['ENTRADAS', 'PIZZAS', 'FONDOS', 'POSTRES', 'BAR', 'VINOS', 'SEMANAL'];
 
 const TAB_BG: Record<MenuTab, string> = {
   ENTRADAS: '#152A1C',
@@ -135,14 +135,18 @@ const IconGlutenFree = () => (
   </svg>
 );
 
-type Props = { menu?: Record<MenuTab, MenuGroup[]> }
+type Props = { menu?: Record<MenuTab, MenuGroup[]>; showSemanal?: boolean }
 
-export default function Menu({ menu }: Props) {
+export default function Menu({ menu, showSemanal = true }: Props) {
   const t = useTranslations('menu');
   const locale = useLocale();
   const [active, setActive] = useState<MenuTab | null>(null);
   const [activeSubtab, setActiveSubtab] = useState('Todos');
   const resolvedMenu = menu ?? FALLBACK_MENU;
+  const TABS = useMemo(
+    () => (showSemanal ? ALL_TABS : ALL_TABS.filter(tab => tab !== 'SEMANAL')),
+    [showSemanal],
+  );
   const groups = active ? resolvedMenu[active] : [];
   const tabsRef = useRef<HTMLDivElement>(null);
   const tabsFade = useScrollFade(tabsRef);
@@ -183,7 +187,7 @@ export default function Menu({ menu }: Props) {
   useEffect(() => {
     const hash = window.location.hash.slice(1).toUpperCase() as MenuTab;
     if (TABS.includes(hash)) setActive(hash);
-  }, []);
+  }, [TABS]);
 
   useEffect(() => {
     setActiveSubtab('Todos');

--- a/lib/menu.ts
+++ b/lib/menu.ts
@@ -75,6 +75,27 @@ const DAY_KEYS = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado
 const WEEKDAY_TO_KEY = { Sun: 'Domingo', Mon: 'Lunes', Tue: 'Martes', Wed: 'Miércoles', Thu: 'Jueves', Fri: 'Viernes', Sat: 'Sábado' } as const
 const CHILE_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', { timeZone: 'America/Santiago', weekday: 'short' })
 
+// Menú Semanal = menú de almuerzo, no se sirve fin de semana y solo hasta las
+// 16:00 (el copy "Disponible hasta las 16:00 hrs" ya lo decía, esto lo hace real).
+const CHILE_TIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Santiago',
+  weekday: 'short',
+  hour: 'numeric',
+  minute: 'numeric',
+  hourCycle: 'h23',
+})
+const SEMANAL_CUTOFF_MINUTES = 16 * 60 // visible hasta las 16:00 inclusive, oculto desde 16:01
+
+export function shouldShowSemanal(now: Date = new Date()): boolean {
+  const parts = CHILE_TIME_FORMATTER.formatToParts(now)
+  const weekday = parts.find(p => p.type === 'weekday')?.value
+  if (weekday === 'Sat' || weekday === 'Sun') return false
+
+  const hour = Number(parts.find(p => p.type === 'hour')?.value)
+  const minute = Number(parts.find(p => p.type === 'minute')?.value)
+  return hour * 60 + minute <= SEMANAL_CUTOFF_MINUTES
+}
+
 function parseMenuPages(
   pages: NotionMenuPage[],
   isEn: boolean,

--- a/tests/e2e/carta-semanal.spec.ts
+++ b/tests/e2e/carta-semanal.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+// Instantes UTC verificados contra America/Santiago (ver commit): lunes 14:00,
+// lunes 16:01 y sábado 10:00 hora de Chile — evita adivinar el offset de DST.
+const MONDAY_BEFORE_CUTOFF = '2026-08-17T18:00:00Z'; // lunes 14:00
+const MONDAY_AFTER_CUTOFF = '2026-08-17T20:01:00Z'; // lunes 16:01
+const SATURDAY_MORNING = '2026-08-22T14:00:00Z'; // sábado 10:00
+
+function withNow(page: import('@playwright/test').Page, iso: string) {
+  return page.route('**/carta', route =>
+    route.continue({ headers: { ...route.request().headers(), 'x-e2e-now': iso } })
+  );
+}
+
+test.describe('Visibilidad de MENÚ SEMANAL según día/hora (Chile)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('dimoe_lead_carta_submitted', '1'));
+  });
+
+  test('lunes antes de las 16:00 muestra el tab MENÚ SEMANAL', async ({ page }) => {
+    await withNow(page, MONDAY_BEFORE_CUTOFF);
+    await page.goto('/carta');
+    await expect(page.locator('[data-tab="SEMANAL"]')).toBeVisible();
+  });
+
+  test('lunes a las 16:01 oculta el tab MENÚ SEMANAL', async ({ page }) => {
+    await withNow(page, MONDAY_AFTER_CUTOFF);
+    await page.goto('/carta');
+    await expect(page.locator('[data-tab="SEMANAL"]')).toHaveCount(0);
+  });
+
+  test('sábado oculta el tab MENÚ SEMANAL incluso temprano', async ({ page }) => {
+    await withNow(page, SATURDAY_MORNING);
+    await page.goto('/carta');
+    await expect(page.locator('[data-tab="SEMANAL"]')).toHaveCount(0);
+  });
+
+  test('deep-link a #semanal no activa el tab cuando está oculto', async ({ page }) => {
+    await withNow(page, SATURDAY_MORNING);
+    await page.goto('/carta#semanal');
+    await expect(page.getByRole('heading', { name: 'MENÚ SEMANAL' })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Regla de negocio: el menú de almuerzo (MENÚ SEMANAL) no se sirve fin de semana, y entre semana solo hasta las 16:00 hrs inclusive (el copy "Disponible hasta las 16:00 hrs" ya existía, esto lo hace real).
- `lib/menu.ts`: `shouldShowSemanal()` calcula día+hora en timezone de Chile (`Intl.DateTimeFormat`, mismo patrón que el filtro de día por ítem ya existente).
- `Menu.tsx`: `TABS` pasa de const de módulo a `useMemo` basado en un nuevo prop `showSemanal` — excluir `'SEMANAL'` del array cubre los 3 puntos de acceso a la vez: barra de tabs, grid del home, y el hash deep-link `#semanal`.
- Test-seam nuevo (header `x-e2e-now`, gateado por `PLAYWRIGHT_E2E=true`) para testear día/hora específicos sin depender del reloj real del momento en que corre CI.

Closes #289

## Test plan
- [x] `pnpm tsc --noEmit` limpio
- [x] Suite completa E2E: 60/60 verde en 2 corridas consecutivas
- [x] Verificación visual (screenshots): grid del home se reacomoda limpio sin la tarjeta SEMANAL cuando está oculta, sin huecos